### PR TITLE
Add type hint to tests

### DIFF
--- a/tests/_exprs/test_signs.py
+++ b/tests/_exprs/test_signs.py
@@ -1,6 +1,9 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+from typing import Any
+
 import pytest
+from pytest import FixtureRequest
 
 from aioway._exprs import OpSign, TypeList
 
@@ -12,19 +15,19 @@ def _signature_str():
 
 
 @pytest.fixture(params=_signature_str())
-def signature(request):
+def signature(request: FixtureRequest):
     return OpSign.parse(request.param, int=int, float=float, bool=bool)
 
 
-def test_signature_param(signature):
+def test_signature_param(signature: OpSign[Any]):
     assert len(signature.param_types) == 2
 
 
 @pytest.fixture
-def type_list():
+def type_list() -> TypeList:
     return TypeList(int, int, float)
 
 
-def test_param_list_compat(type_list):
+def test_param_list_compat(type_list: TypeList):
     assert type_list.check_values([1, 2, 3.0])
     assert not type_list.check_values([1.0, 2, 3.0])

--- a/tests/attrs/test_devices.py
+++ b/tests/attrs/test_devices.py
@@ -2,6 +2,7 @@
 
 import pytest
 import torch
+from pytest import FixtureRequest
 
 from aioway import attrs
 
@@ -12,7 +13,7 @@ def _cpus():
 
 
 @pytest.fixture(params=_cpus())
-def cpu(request):
+def cpu(request: FixtureRequest):
     return attrs.device(request.param)
 
 

--- a/tests/attrs/test_devices.py
+++ b/tests/attrs/test_devices.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from pytest import FixtureRequest
 
-from aioway import attrs
+from aioway.attrs import Device
 
 
 def _cpus():
@@ -14,13 +14,13 @@ def _cpus():
 
 @pytest.fixture(params=_cpus())
 def cpu(request: FixtureRequest):
-    return attrs.device(request.param)
+    return Device.parse(request.param)
 
 
-def test_eq(cpu):
+def test_eq(cpu: Device):
     assert cpu == "cpu"
-    assert cpu == attrs.device("cpu")
+    assert cpu == Device.parse("cpu")
 
 
-def test_no_fail(cpu):
+def test_no_fail(cpu: Device):
     assert cpu != object()

--- a/tests/attrs/test_dtypes.py
+++ b/tests/attrs/test_dtypes.py
@@ -73,5 +73,5 @@ def golden(request: FixtureRequest) -> _CaseChecker:
     return request.param
 
 
-def test_dtype_cases(golden):
+def test_dtype_cases(golden: _CaseChecker):
     golden.check()

--- a/tests/attrs/test_dtypes.py
+++ b/tests/attrs/test_dtypes.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pytest
 import torch
+from pytest import FixtureRequest
 
 from aioway import attrs
 from aioway.attrs import DType
@@ -68,7 +69,7 @@ def _dtypes():
 
 
 @pytest.fixture(params=_golden())
-def golden(request) -> _CaseChecker:
+def golden(request: FixtureRequest) -> _CaseChecker:
     return request.param
 
 

--- a/tests/attrs/test_shapes.py
+++ b/tests/attrs/test_shapes.py
@@ -17,26 +17,26 @@ def shape(request: FixtureRequest) -> Shape:
     return request.param
 
 
-def test_shape_getitem(shape):
+def test_shape_getitem(shape: Shape):
     assert shape[0] == 3
     assert shape[1] == 5
     assert shape[2] == 7
 
 
-def test_shape_size(shape):
+def test_shape_size(shape: Shape):
     assert shape.size == 3 * 5 * 7
 
 
-def test_shape_ndim(shape):
+def test_shape_ndim(shape: Shape):
     assert shape.ndim == 3
 
 
-def test_shape_no_fail(shape):
+def test_shape_no_fail(shape: Shape):
     "Ensure that shapes do not crash when the other type is not recognized."
 
     assert shape != object()
 
 
-def test_shape_ndarray(shape):
+def test_shape_ndarray(shape: Shape):
     assert shape == np.array([3, 5, 7])
     assert shape != np.array([[3, 5, 7]])

--- a/tests/attrs/test_shapes.py
+++ b/tests/attrs/test_shapes.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from pytest import FixtureRequest
 
 from aioway.attrs import Shape
 
@@ -12,7 +13,7 @@ def _shapes():
 
 
 @pytest.fixture(params=_shapes())
-def shape(request) -> Shape:
+def shape(request: FixtureRequest) -> Shape:
     return request.param
 
 

--- a/tests/attrs/test_validation.py
+++ b/tests/attrs/test_validation.py
@@ -11,7 +11,7 @@ from aioway.chunks import Chunk
 
 
 @pytest.fixture
-def schema():
+def schema() -> AttrSet:
     return AttrSet.from_values(
         a=attrs.attr(
             device="cpu",
@@ -27,7 +27,7 @@ def schema():
 
 
 @pytest.fixture
-def valid_data():
+def valid_data() -> TensorDict:
     result = TensorDict(
         {
             "a": torch.randn(11, 2, 3).to(torch.int32),
@@ -61,11 +61,11 @@ def invalid_data(request: FixtureRequest) -> TensorDict:
     return request.param
 
 
-def test_validation_ok(schema, valid_data):
+def test_validation_ok(schema: AttrSet, valid_data: TensorDict) -> None:
     _validation.validate_schema(schema, valid_data)
 
 
-def test_construction_of_attrset(valid_data):
+def test_construction_of_attrset(valid_data: TensorDict):
     parsed = AttrSet.from_tensordict(valid_data)
     assert parsed == attrs.attr_set(
         {
@@ -75,15 +75,15 @@ def test_construction_of_attrset(valid_data):
     )
 
 
-def test_validation_fail(schema, invalid_data):
+def test_validation_fail(schema: AttrSet, valid_data: TensorDict):
     with pytest.raises(RuntimeError):
         _validation.validate_schema(schema, invalid_data)
 
 
 @pytest.fixture
-def block(schema, valid_data):
+def block(schema: AttrSet, valid_data: TensorDict) -> Chunk:
     return Chunk.from_data_schema(data=valid_data, schema=schema)
 
 
-def test_block_init(block):
+def test_block_init(block: Chunk):
     _ = block

--- a/tests/attrs/test_validation.py
+++ b/tests/attrs/test_validation.py
@@ -2,6 +2,7 @@
 
 import pytest
 import torch
+from pytest import FixtureRequest
 from tensordict import TensorDict
 
 from aioway import attrs
@@ -56,7 +57,7 @@ def _invalid_data():
 
 
 @pytest.fixture(params=_invalid_data())
-def invalid_data(request) -> TensorDict:
+def invalid_data(request: FixtureRequest) -> TensorDict:
     return request.param
 
 

--- a/tests/attrs/test_validation.py
+++ b/tests/attrs/test_validation.py
@@ -75,7 +75,7 @@ def test_construction_of_attrset(valid_data: TensorDict):
     )
 
 
-def test_validation_fail(schema: AttrSet, valid_data: TensorDict):
+def test_validation_fail(schema: AttrSet, invalid_data: TensorDict):
     with pytest.raises(RuntimeError):
         _validation.validate_schema(schema, invalid_data)
 

--- a/tests/batches/test_fake.py
+++ b/tests/batches/test_fake.py
@@ -4,30 +4,32 @@ import numpy as np
 import pytest
 import torch
 from numpy import random as np_rand
+from pytest import FixtureRequest
 
+from aioway.chunks import Chunk
 from tests import fake
 
 
 @pytest.fixture(params=fake.cpu_and_maybe_cuda(), scope="session")
-def device(request) -> str:
+def device(request: FixtureRequest) -> str:
     return request.param
 
 
 @pytest.fixture(params=fake.batch_sizes(), scope="module")
-def batch(request) -> int:
+def batch(request: FixtureRequest) -> int:
     return request.param
 
 
-def test_chunk_init_success(device, batch):
+def test_chunk_init_success(device: str, batch: int) -> None:
     _ = fake.chunk_ok(device=device, size=batch)
 
 
-def test_chunk_len(device, batch):
+def test_chunk_len(device: str, batch: int) -> None:
     block = fake.chunk_ok(device=device, size=batch)
     assert len(block) == batch
 
 
-def test_chunk_getitem_size(device, batch):
+def test_chunk_getitem_size(device: str, batch: int) -> None:
     block = fake.chunk_ok(device=device, size=batch)
 
     assert len(block[batch - 1 : batch]) == 1
@@ -39,7 +41,7 @@ def test_chunk_getitem_size(device, batch):
     assert len(block[torch_idx]) == (torch_idx > 0).sum()
 
     # Int index in torch.
-    indexed = block[torch.arange(len(torch_idx))[torch_idx]]
+    indexed: Chunk = block[torch.arange(len(torch_idx))[torch_idx]]
     assert len(indexed) == (torch_idx > 0).sum().item()
 
     # Bool index in numpy.
@@ -50,6 +52,6 @@ def test_chunk_getitem_size(device, batch):
     assert len(block[np.arange(len(np_idx))[np_idx]]) == np_idx.sum()
 
 
-def test_chunk_keys(device, batch):
+def test_chunk_keys(device: str, batch: int) -> None:
     block = fake.chunk_ok(device=device, size=batch)
     assert set(block.keys()) == {"f1d", "f2d", "i1d", "i2d"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import random
 import pytest
 import torch
 from numpy import random as npr
+from pytest import FixtureRequest
 from rich import traceback
 
 from . import fake
@@ -28,7 +29,7 @@ def seed():
 
 
 @pytest.fixture(params=fake.cpu_and_maybe_cuda())
-def device(request) -> str:
+def device(request: FixtureRequest) -> str:
     return request.param
 
 
@@ -38,5 +39,5 @@ def data_size() -> int:
 
 
 @pytest.fixture(params=fake.batch_sizes())
-def batch_size(request) -> int:
+def batch_size(request: FixtureRequest) -> int:
     return request.param

--- a/tests/datasets/frames/conftest.py
+++ b/tests/datasets/frames/conftest.py
@@ -1,6 +1,7 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 import pytest
+from pytest import FixtureRequest
 
 from aioway.datasets import (
     ChunkFrame,
@@ -27,12 +28,14 @@ def list_table(device: str, batch_size: int, data_size: int):
 
 
 @pytest.fixture(params=[block_table, list_table])
-def frame(request, device, batch_size, data_size) -> Frame:
+def frame(
+    request: FixtureRequest, device: str, batch_size: int, data_size: int
+) -> Frame:
     return request.param(device=device, batch_size=batch_size, data_size=data_size)
 
 
 @pytest.fixture
-def table_stream(frame, batch_size):
+def table_stream(frame: Frame, batch_size: int):
     return FrameStream(
         frame,
         FrameStreamLoader(batch_size=batch_size),

--- a/tests/datasets/frames/test_frames.py
+++ b/tests/datasets/frames/test_frames.py
@@ -5,14 +5,15 @@ import pytest
 from numpy import random
 
 from aioway.chunks import Chunk
+from aioway.datasets import Frame
 
 
-def test_table_not_empty(frame):
+def test_table_not_empty(frame: Frame):
     assert frame
     assert len(frame)
 
 
-def test_table_idx_arr(frame):
+def test_table_idx_arr(frame: Frame):
     idx = random.randint(low=-len(frame), high=len(frame), size=[len(frame)])
 
     assert np.all(-len(frame) <= idx)
@@ -24,12 +25,12 @@ def test_table_idx_arr(frame):
     assert len(out) == len(idx)
 
 
-def test_table_idx_slice(frame):
+def test_table_idx_slice(frame: Frame):
     out = frame[-len(frame) : len(frame)]
     assert isinstance(out, Chunk)
     assert len(out) == len(frame)
 
 
-def test_table_out_of_bounds(frame):
+def test_table_out_of_bounds(frame: Frame):
     with pytest.raises(IndexError):
         _ = frame[[-2 * len(frame)]]

--- a/tests/datasets/frames/test_views.py
+++ b/tests/datasets/frames/test_views.py
@@ -1,7 +1,9 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+from aioway.datasets import Frame
 
-def test_column_attr(frame):
+
+def test_column_attr(frame: Frame) -> None:
     attrs = frame.attrs
     first_key = list(attrs.keys())[0]
 
@@ -9,7 +11,7 @@ def test_column_attr(frame):
     assert frame.select(first_key).attrs == attrs.select(first_key)
 
 
-def test_select_attr(frame):
+def test_select_attr(frame: Frame) -> None:
     attrs = frame.attrs
     two_keys = list(attrs.keys())[:2]
 

--- a/tests/datasets/streams/conftest.py
+++ b/tests/datasets/streams/conftest.py
@@ -9,13 +9,13 @@ from tests import fake
 
 
 @pytest.fixture
-def block_table(device, data_size):
+def block_table(device, data_size) -> ChunkFrame:
     block = fake.chunk_ok(size=data_size, device=device)
     return ChunkFrame(data=block)
 
 
 @pytest.fixture
-def table_stream(block_table, batch_size):
+def table_stream(block_table, batch_size) -> FrameStream:
     return FrameStream(
         frame=block_table,
         options=FrameStreamLoader(batch_size=batch_size),
@@ -23,13 +23,13 @@ def table_stream(block_table, batch_size):
 
 
 @pytest.fixture
-def concat_frame(device, data_size):
+def concat_frame(device, data_size) -> ChunkFrame:
     block = fake.concat_ok(size=data_size, device=device)
     return ChunkFrame(data=block)
 
 
 @pytest.fixture
-def concat_stream(concat_frame, batch_size):
+def concat_stream(concat_frame, batch_size) -> FrameStream:
     return FrameStream(
         frame=concat_frame,
         options=FrameStreamLoader(batch_size=batch_size),
@@ -37,7 +37,7 @@ def concat_stream(concat_frame, batch_size):
 
 
 @pytest.fixture
-def joinable_frame(device, data_size):
+def joinable_frame(device, data_size) -> ChunkFrame:
     "`Frame` for joining on the RHS."
 
     block = fake.unionable_ok(size=data_size, device=device)
@@ -45,7 +45,7 @@ def joinable_frame(device, data_size):
 
 
 @pytest.fixture
-def joinable_stream(joinable_frame, batch_size):
+def joinable_stream(joinable_frame, batch_size) -> FrameStream:
     "`Stream` for joining on the RHS."
     return FrameStream(
         frame=joinable_frame,

--- a/tests/datasets/streams/conftest.py
+++ b/tests/datasets/streams/conftest.py
@@ -4,8 +4,7 @@
 
 import pytest
 
-from aioway.datasets import ChunkFrame, FrameStream, FrameStreamLoader
-from aioway.datasets import Frame
+from aioway.datasets import ChunkFrame, Frame, FrameStream, FrameStreamLoader
 from tests import fake
 
 

--- a/tests/datasets/streams/conftest.py
+++ b/tests/datasets/streams/conftest.py
@@ -5,17 +5,18 @@
 import pytest
 
 from aioway.datasets import ChunkFrame, FrameStream, FrameStreamLoader
+from aioway.datasets import Frame
 from tests import fake
 
 
 @pytest.fixture
-def block_table(device, data_size) -> ChunkFrame:
+def block_table(device: str, data_size: int) -> ChunkFrame:
     block = fake.chunk_ok(size=data_size, device=device)
     return ChunkFrame(data=block)
 
 
 @pytest.fixture
-def table_stream(block_table, batch_size) -> FrameStream:
+def table_stream(block_table: Frame, batch_size: int) -> FrameStream:
     return FrameStream(
         frame=block_table,
         options=FrameStreamLoader(batch_size=batch_size),
@@ -23,13 +24,13 @@ def table_stream(block_table, batch_size) -> FrameStream:
 
 
 @pytest.fixture
-def concat_frame(device, data_size) -> ChunkFrame:
+def concat_frame(device: str, data_size: int) -> ChunkFrame:
     block = fake.concat_ok(size=data_size, device=device)
     return ChunkFrame(data=block)
 
 
 @pytest.fixture
-def concat_stream(concat_frame, batch_size) -> FrameStream:
+def concat_stream(concat_frame: Frame, batch_size: int) -> FrameStream:
     return FrameStream(
         frame=concat_frame,
         options=FrameStreamLoader(batch_size=batch_size),
@@ -37,7 +38,7 @@ def concat_stream(concat_frame, batch_size) -> FrameStream:
 
 
 @pytest.fixture
-def joinable_frame(device, data_size) -> ChunkFrame:
+def joinable_frame(device: str, data_size: int) -> ChunkFrame:
     "`Frame` for joining on the RHS."
 
     block = fake.unionable_ok(size=data_size, device=device)
@@ -45,7 +46,7 @@ def joinable_frame(device, data_size) -> ChunkFrame:
 
 
 @pytest.fixture
-def joinable_stream(joinable_frame, batch_size) -> FrameStream:
+def joinable_stream(joinable_frame: Frame, batch_size: int) -> FrameStream:
     "`Stream` for joining on the RHS."
     return FrameStream(
         frame=joinable_frame,

--- a/tests/datasets/streams/test_binary.py
+++ b/tests/datasets/streams/test_binary.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 import pytest
 import torch
-
+from pytest import FixtureRequest
 from aioway import attrs
 from aioway.chunks import Chunk
 from aioway.datasets import (
@@ -18,25 +18,25 @@ from aioway.datasets import (
 
 
 @pytest.fixture
-def lhs_stream(concat_stream):
+def lhs_stream(concat_stream: Stream) -> CacheStream:
     return CacheStream(concat_stream)
 
 
 @pytest.fixture
-def rhs_stream(joinable_stream):
+def rhs_stream(joinable_stream: Stream) -> CacheStream:
     return CacheStream(joinable_stream)
 
 
-def test_lhs_stream_length(concat_stream, lhs_stream):
+def test_lhs_stream_length(concat_stream: Stream, lhs_stream: Stream):
     assert concat_stream.size == lhs_stream.size
 
 
-def test_rhs_stream_length(joinable_stream, rhs_stream):
+def test_rhs_stream_length(joinable_stream: Stream, rhs_stream: CacheStream):
     assert joinable_stream.size == rhs_stream.size
 
 
 @pytest.fixture
-def binary_stream(request, lhs_stream, rhs_stream):
+def binary_stream(request: FixtureRequest, lhs_stream: Stream, rhs_stream: CacheStream):
     "An indirect fixture that takes in a builder function and outputs a stream."
 
     builder: Callable[[Stream, Stream], Stream] = request.param
@@ -49,21 +49,19 @@ def binary_stream(request, lhs_stream, rhs_stream):
     return result
 
 
-def _zip_builder(lhs_stream, rhs_stream):
+def _zip_builder(lhs_stream: Stream, rhs_stream: CacheStream):
     return ZipStream(left=lhs_stream, right=rhs_stream)
 
 
 @pytest.mark.parametrize("binary_stream", [_zip_builder], indirect=True)
-def test_zip_input_len(binary_stream, concat_stream, rhs_stream):
+def test_zip_input_len(
+    binary_stream: Stream, concat_stream: Stream, rhs_stream: CacheStream
+):
     assert min(concat_stream.size, rhs_stream.size) == binary_stream.size
 
 
 @pytest.mark.parametrize("binary_stream", [_zip_builder], indirect=True)
-def test_zip(
-    binary_stream,
-    lhs_stream,
-    rhs_stream,
-):
+def test_zip(binary_stream: Stream, lhs_stream: Stream, rhs_stream: Stream):
     assert not lhs_stream.started
     assert not rhs_stream.started
     assert not binary_stream.started
@@ -75,12 +73,14 @@ def test_zip(
         assert result == concat
 
 
-def _join_builder(lhs_stream, rhs_stream):
+def _join_builder(lhs_stream: Stream, rhs_stream: CacheStream):
     return NestedLoopJoinStream(left=lhs_stream, right=rhs_stream, key="i1d")
 
 
 @pytest.mark.parametrize("binary_stream", [_join_builder], indirect=True)
-def test_join_input_len(binary_stream, lhs_stream, rhs_stream):
+def test_join_input_len(
+    binary_stream: Stream, lhs_stream: Stream, rhs_stream: CacheStream
+):
     assert binary_stream.size == lhs_stream.size * rhs_stream.size
 
 
@@ -151,7 +151,9 @@ def test_simple_nested_loop_join(to_slice: Callable[[Chunk], list[Chunk]]):
 
 
 @pytest.mark.parametrize("binary_stream", [_join_builder], indirect=True)
-def test_join_equal_as_original(binary_stream, lhs_stream, rhs_stream):
+def test_join_equal_as_original(
+    binary_stream: Stream, lhs_stream: Stream, rhs_stream: CacheStream
+):
     block_frame_block = Chunk.cat(list(lhs_stream))
     joinable_frame_block = Chunk.cat(list(rhs_stream))
 
@@ -178,7 +180,9 @@ def test_join_equal_as_original(binary_stream, lhs_stream, rhs_stream):
 
 
 @pytest.mark.parametrize("binary_stream", [_join_builder], indirect=True)
-def test_match_functionally(binary_stream, lhs_stream, rhs_stream):
+def test_match_functionally(
+    binary_stream: Stream, lhs_stream: Stream, rhs_stream: CacheStream
+):
     block_frame_block = Chunk.cat(list(lhs_stream))
     joinable_frame_block = Chunk.cat(list(rhs_stream))
 

--- a/tests/datasets/streams/test_binary.py
+++ b/tests/datasets/streams/test_binary.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import pytest
 import torch
 from pytest import FixtureRequest
+
 from aioway import attrs
 from aioway.chunks import Chunk
 from aioway.datasets import (

--- a/tests/datasets/streams/test_maps.py
+++ b/tests/datasets/streams/test_maps.py
@@ -5,6 +5,7 @@ import typing
 from collections.abc import Callable
 
 import pytest
+from pytest import FixtureRequest
 
 from aioway.attrs import AttrSet
 from aioway.chunks import Chunk
@@ -48,14 +49,14 @@ class SaveLastMapStream(MapStream):
 
 
 @pytest.fixture
-def save_last(table_stream):
+def save_last(table_stream: Stream):
     "The stream that is wrapped, preserving the last item."
 
     return SaveLastMapStream(table_stream)
 
 
 @pytest.fixture
-def map_stream(request, save_last):
+def map_stream(request: FixtureRequest, save_last: SaveLastMapStream):
     "Indirect fixture to create `MapStream`s based on a builder function."
 
     builder: Callable[[Stream], MapStream] = request.param
@@ -74,7 +75,7 @@ def _pred_filter_builder(source):
 
 
 @pytest.mark.parametrize("map_stream", [_pred_filter_builder], indirect=True)
-def test_filter(map_stream, save_last):
+def test_filter(map_stream: Stream, save_last: SaveLastMapStream):
     "Testing the 2 filter streams and whether they are doing their jobs."
 
     for filtered in map_stream:
@@ -87,13 +88,13 @@ def test_filter(map_stream, save_last):
         assert filtered == manual_filtered
 
 
-def _rename_builder(save_last):
+def _rename_builder(save_last: SaveLastMapStream):
     renames = {"f1d": "f1", "f2d": "f2", "i1d": "i1", "i2d": "i2"}
     return RenameStream(source=save_last, renames=renames)
 
 
 @pytest.mark.parametrize("map_stream", [_rename_builder], indirect=True)
-def test_rename(map_stream, save_last):
+def test_rename(map_stream: Stream, save_last: SaveLastMapStream):
     "Testing the renaming functionality."
 
     for renamed in map_stream:
@@ -101,24 +102,24 @@ def test_rename(map_stream, save_last):
         assert renamed == manual_renamed
 
 
-def _apply_builder(save_last):
+def _apply_builder(save_last: SaveLastMapStream):
     func = lambda td: td.rename(f1d="f", i1d="i")
     schema = lambda attrs: attrs.rename(f1d="f", i1d="i")
     return ApplyStream(source=save_last, apply=func, schema=schema)
 
 
 @pytest.mark.parametrize("map_stream", [_apply_builder], indirect=True)
-def test_apply(map_stream, save_last):
+def test_apply(map_stream: Stream, save_last: SaveLastMapStream):
     for mapped in map_stream:
         assert mapped == map_stream.apply(save_last.last)
 
 
-def _project_builder(save_last):
+def _project_builder(save_last: SaveLastMapStream):
     return ProjectStream(source=save_last, subset=["f1d", "i2d"])
 
 
 @pytest.mark.parametrize("map_stream", [_project_builder], indirect=True)
-def test_project(map_stream, save_last):
+def test_project(map_stream: Stream, save_last: SaveLastMapStream):
     for projected in map_stream:
         assert projected == save_last.last[["f1d", "i2d"]]
 
@@ -133,7 +134,7 @@ def test_project(map_stream, save_last):
     ],
     indirect=True,
 )
-def test_map_stream_one_to_one(map_stream, save_last):
+def test_map_stream_one_to_one(map_stream: Stream, save_last: SaveLastMapStream):
     assert (
         map_stream.source is save_last
     ), f"Malformed input {map_stream}, should have source={save_last}"
@@ -152,6 +153,6 @@ def test_map_stream_one_to_one(map_stream, save_last):
 @pytest.mark.parametrize(
     "map_stream", [_project_builder, _apply_builder], indirect=True
 )
-def test_caching(map_stream):
+def test_caching(map_stream: Stream):
     cached = CacheStream(map_stream)
     assert cached.size == map_stream.size

--- a/tests/datasets/streams/test_seed.py
+++ b/tests/datasets/streams/test_seed.py
@@ -1,5 +1,5 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 
-def test_seed(seed):
+def test_seed(seed: int):
     assert seed == 42

--- a/tests/datasets/streams/test_views.py
+++ b/tests/datasets/streams/test_views.py
@@ -1,7 +1,9 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+from aioway.datasets import Stream
 
-def test_column_attr(table_stream):
+
+def test_column_attr(table_stream: Stream):
     attrs = table_stream.attrs
     first_key = list(attrs.keys())[0]
 
@@ -9,7 +11,7 @@ def test_column_attr(table_stream):
     assert table_stream.select(first_key).attrs == attrs.select(first_key)
 
 
-def test_select_attr(table_stream):
+def test_select_attr(table_stream: Stream):
     attrs = table_stream.attrs
     two_keys = list(attrs.keys())[:2]
 

--- a/tests/fake.py
+++ b/tests/fake.py
@@ -1,6 +1,5 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-
 import numpy as np
 import torch
 from tensordict import TensorDict
@@ -31,7 +30,7 @@ def batch_sizes():
     yield 1024
 
 
-def chunk_ok(*, size: int, device: str):
+def chunk_ok(*, size: int, device: str) -> Chunk:
     data = TensorDict(
         {
             "f1d": torch.randn(size),

--- a/tests/symbols/test_symbols.py
+++ b/tests/symbols/test_symbols.py
@@ -2,14 +2,12 @@
 
 import operator
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import pytest
+from pytest import FixtureRequest
 
-from aioway.symbols import (
-    ColSymExpr,
-    SourceExpr,
-)
+from aioway.symbols import ColSymExpr, SourceExpr
 
 
 @pytest.fixture
@@ -38,11 +36,11 @@ def e(b: SourceExpr):
 
 
 @pytest.fixture(params="cde")
-def col_expr(request) -> ColSymExpr:
+def col_expr(request: FixtureRequest) -> ColSymExpr:
     return request.getfixturevalue(request.param)
 
 
-def test_col_repr(c, d, e):
+def test_col_repr(c: str, d: str, e: str):
     assert str(c) == "a.c"
     assert str(d) == "a.d"
     assert str(e) == "b.e"
@@ -64,7 +62,9 @@ class _OpFunc(NamedTuple):
         _OpFunc("**", operator.pow),
     ],
 )
-def test_infix_op_repr(c, d, op, func) -> None:
+def test_infix_op_repr(
+    c: str, d: str, op: str, func: Callable[[Any, Any], Any]
+) -> None:
     assert str(func(c, d)) == f"{c!s} {op} {d!s}"
 
 
@@ -85,7 +85,9 @@ def test_infix_op_repr(c, d, op, func) -> None:
         _OpFunc("<", operator.lt),
     ],
 )
-def test_binray_ufunc_repr(c, d, op, func) -> None:
+def test_binray_ufunc_repr(
+    c: str, d: str, op: str, func: Callable[[Any, Any], Any]
+) -> None:
     assert str(func(c, d)) == f"{c!s} {op} {d!s}"
     assert str(func(d, c)) == f"{d!s} {op} {c!s}"
 
@@ -107,7 +109,7 @@ def test_binray_ufunc_repr(c, d, op, func) -> None:
         operator.le,
     ],
 )
-def test_binary_ufunc_type(c, e, op) -> None:
+def test_binary_ufunc_type(c: str, e: str, op: Callable[[Any, Any], Any]) -> None:
     assert isinstance(expr := op(c, e), ColSymExpr), type(expr)
     assert isinstance(expr := op(e, c), ColSymExpr), type(expr)
 
@@ -119,5 +121,5 @@ def test_binary_ufunc_type(c, e, op) -> None:
         _OpFunc("~", operator.inv),
     ],
 )
-def test_prefix_op_repr(col_expr: ColSymExpr, op, func):
+def test_prefix_op_repr(col_expr: ColSymExpr, op: str, func: Callable[[Any, Any], Any]):
     assert str(func(col_expr)) == f"{op}{col_expr!s}"

--- a/tests/symbols/test_symbols.py
+++ b/tests/symbols/test_symbols.py
@@ -11,12 +11,12 @@ from aioway.symbols import ColSymExpr, SourceExpr
 
 
 @pytest.fixture
-def a():
+def a() -> SourceExpr:
     return SourceExpr("a", "cde")
 
 
 @pytest.fixture
-def b():
+def b() -> SourceExpr:
     return SourceExpr("b", "cde")
 
 


### PR DESCRIPTION
I added type hints to tests, as I'm no longer using `pylance`.