### PR TITLE
Improve `Fn`'s context

### DIFF
--- a/src/aioway/fn/fn.py
+++ b/src/aioway/fn/fn.py
@@ -129,25 +129,24 @@ class FnStack[F: Fn]:
     `FnStack` is the tracker for `Fn`, storing `Fn`s that are currengly `do()`-ing.
     """
 
-    stack: list[F]
+    stack: list[F] = dcls.field(default_factory=list)
     """
     The stack that is currently in scope.
     """
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(len(self))
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.stack)
 
     @typing.overload
     def __getitem__(self, idx: int) -> F: ...
 
     @typing.overload
-    def __getitem__(self, idx: slice) -> typing.Self: ...
+    def __getitem__(self, idx: slice[int]) -> typing.Self: ...
 
-    @typing.no_type_check
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int | slice[int]):
         match idx:
             case int():
                 return self.stack[idx]
@@ -156,6 +155,12 @@ class FnStack[F: Fn]:
 
         raise TypeError(type(idx))
 
+    def __iter__(self) -> cabc.Generator[F]:
+        yield from self.stack
+
+    def top(self) -> F:
+        return self.stack[-1]
+
     def append(self, fn: F) -> None:
         self.stack.append(fn)
 
@@ -163,13 +168,12 @@ class FnStack[F: Fn]:
         return self.stack.pop()
 
     @ctxl.contextmanager
-    def track_scope(self, fn: F):
+    def track(self, fn: F):
+        self.append(fn)
         try:
             yield
         finally:
-            self.pop()
-
-    # def track_func(self, function: )
+            _ = self.pop()
 
 
 def pretty_function_call(func: str, *args: typing.Any, **kwargs: typing.Any) -> str:

--- a/src/aioway/fn/fn.py
+++ b/src/aioway/fn/fn.py
@@ -2,18 +2,20 @@
 
 "Metadata for torch operators / functions."
 
+import contextlib as ctxl
+import dataclasses as dcls
 import functools
 import typing
 from collections import abc as cabc
 
-__all__ = ["Fn", "Thunk", "pretty_function_call"]
+__all__ = ["Fn", "Thunk", "FnStack", "pretty_function_call"]
 
 _PENDING = object()
 "The object signifying a status of pending. This is a `object()` s.t. `FnCache` can store `None`."
 
 
 class Fn(typing.Protocol):
-    def __call__(self):
+    def do(self):
         raise NotImplementedError
 
 
@@ -67,7 +69,7 @@ class Thunk(Fn):
 
         return NotImplemented
 
-    def __call__(self) -> typing.Any:
+    def do(self) -> typing.Any:
         """
         Call and cache the function.
         """
@@ -119,6 +121,55 @@ class Thunk(Fn):
         "Returns if the cache is previously called."
 
         return self.__result is not _PENDING
+
+
+@dcls.dataclass
+class FnStack[F: Fn]:
+    """
+    `FnStack` is the tracker for `Fn`, storing `Fn`s that are currengly `do()`-ing.
+    """
+
+    stack: list[F]
+    """
+    The stack that is currently in scope.
+    """
+
+    def __bool__(self):
+        return bool(len(self))
+
+    def __len__(self):
+        return len(self.stack)
+
+    @typing.overload
+    def __getitem__(self, idx: int) -> F: ...
+
+    @typing.overload
+    def __getitem__(self, idx: slice) -> typing.Self: ...
+
+    @typing.no_type_check
+    def __getitem__(self, idx):
+        match idx:
+            case int():
+                return self.stack[idx]
+            case slice():
+                return type(self)(self.stack[idx])
+
+        raise TypeError(type(idx))
+
+    def append(self, fn: F) -> None:
+        self.stack.append(fn)
+
+    def pop(self) -> F:
+        return self.stack.pop()
+
+    @ctxl.contextmanager
+    def track_scope(self, fn: F):
+        try:
+            yield
+        finally:
+            self.pop()
+
+    # def track_func(self, function: )
 
 
 def pretty_function_call(func: str, *args: typing.Any, **kwargs: typing.Any) -> str:

--- a/src/aioway/fn/funcs.py
+++ b/src/aioway/fn/funcs.py
@@ -34,7 +34,7 @@ class TrackFunctionMode(overrides.TorchFunctionMode):
         self.functions.append(fn)
 
         with _ensure_single_function(fn):
-            return fn()
+            return fn.do()
 
 
 @ctxl.contextmanager

--- a/src/aioway/fn/funcs.py
+++ b/src/aioway/fn/funcs.py
@@ -9,17 +9,18 @@ import typing
 import torch
 from torch import _ops, overrides
 
-from .fn import Thunk
+from .fn import FnStack, Thunk
 
 __all__ = ["track_function_fn"]
 
-_active_function: Thunk | None = None
-"The current function."
+_function_tracker: _TrackFunctionMode | None = None
+"The current function tracker. It's a singleton."
 
 
 @dcls.dataclass(frozen=True)
-class TrackFunctionMode(overrides.TorchFunctionMode):
+class _TrackFunctionMode(overrides.TorchFunctionMode):
     functions: list[Thunk] = dcls.field(default_factory=list)
+    stack: FnStack[Thunk] = dcls.field(default_factory=FnStack)
 
     @typing.override
     def __torch_function__(
@@ -33,31 +34,45 @@ class TrackFunctionMode(overrides.TorchFunctionMode):
         fn = Thunk(func, *args, **kwargs)
         self.functions.append(fn)
 
-        with _ensure_single_function(fn):
+        with self.stack.track(fn):
             return fn.do()
 
 
 @ctxl.contextmanager
 def track_function_fn():
-    with TrackFunctionMode() as sfm:
-        yield sfm.functions
+    """
+    Activate the tracker that will track all `torch.*` calls.
+    If a tracker is created, it will be reused.
+    """
+
+    global _function_tracker
+
+    # If it already exists, don't create a new one.
+    if _function_tracker:
+        yield _function_tracker.functions
+        return
+
+    # Create a new one, but rememeber to reset it once done.
+    with _TrackFunctionMode() as _function_tracker:
+        try:
+            yield _function_tracker.functions
+        finally:
+            _function_tracker = None
 
 
-@ctxl.contextmanager
-def _ensure_single_function(fn: Thunk):
-    "Ensure that only 1 function is running at any given moment."
+def function_tracker():
+    """
+    Retrieve the current function tracker that is active.
+    Raise `RuntimeError` if one is not found.
+    """
 
-    global _active_function
+    if _function_tracker is None:
+        raise RuntimeError("The function tracker is not active yet.")
 
-    if _active_function is not None:
-        raise ValueError("Cannot run 2 functions at once.")
-
-    try:
-        _active_function = fn
-        yield
-    finally:
-        _active_function = None
+    return _function_tracker
 
 
-def active_function():
-    return _active_function
+def torch_function_stack():
+    "Get the `__torch_function__` stack that is used when `track_function_fn` is enabled."
+
+    return function_tracker().stack

--- a/src/aioway/fn/ops/aten/binary.py
+++ b/src/aioway/fn/ops/aten/binary.py
@@ -64,7 +64,7 @@ class _BinaryTensorUFunc(Preview, abc.ABC):
             return False
 
     @typing.override
-    def __call__(self) -> torch.Tensor:
+    def do(self) -> torch.Tensor:
         return self.BINARY(self.self, self.other * self.alpha)
 
     @typing.final
@@ -99,7 +99,7 @@ class _BinaryScalarUFunc(Preview, abc.ABC):
         return True
 
     @typing.override
-    def __call__(self) -> torch.Tensor:
+    def do(self) -> torch.Tensor:
         return self.BINARY(self.self, self.other)
 
     @typing.final

--- a/src/aioway/fn/ops/aten/getitem.py
+++ b/src/aioway/fn/ops/aten/getitem.py
@@ -26,6 +26,10 @@ class _GetItem(Preview, abc.ABC):
         yield self.self
         yield from self.indices
 
+    @typing.override
+    def cost(self) -> int:
+        return self.do().numel()
+
 
 @dcls_no_repr
 class BooleanMasking(_GetItem):
@@ -33,12 +37,8 @@ class BooleanMasking(_GetItem):
         return len(self.indices) == 1 and self.indices[0].dtype == torch.bool
 
     @typing.override
-    def __call__(self) -> torch.Tensor:
+    def do(self) -> torch.Tensor:
         return self.self
-
-    @typing.override
-    def cost(self) -> int:
-        return self().numel()
 
 
 @dcls_no_repr
@@ -47,9 +47,5 @@ class IntSelect(_GetItem):
         return len(self.indices) == 1 and self.indices[0].dtype == torch.int
 
     @typing.override
-    def __call__(self):
+    def do(self):
         return self.self[self.indices]
-
-    @typing.override
-    def cost(self) -> int:
-        return self().numel()

--- a/src/aioway/fn/ops/fn.py
+++ b/src/aioway/fn/ops/fn.py
@@ -11,17 +11,24 @@ import torch
 from torch import _ops
 
 from aioway._common.dcls import dcls_no_repr
+from aioway.fn.funcs import torch_function_stack
 
 from ..fn import Fn, Thunk, pretty_function_call
 from ..guards import TensorFilter, all_tensors
 
-__all__ = ["find_preview", "all_previews", "TorchFn", "Preview", "TorchThunk"]
+__all__ = ["find_preview", "all_previews", "TorchFn", "Preview", "TorchDispatchThunk"]
 
 
 _PREVIEW_CANDIDATES: dict[_ops.OpOverload, list[cabc.Callable[..., Preview]]] = {}
 
 
 class TorchFn(Fn, abc.ABC):
+    def __init__(self):
+        try:
+            self._torch_function = torch_function_stack().top()
+        except IndexError:
+            raise RuntimeError("There are no `__torch_function__` calls active!")
+
     @abc.abstractmethod
     @typing.override
     def do(self) -> torch.Tensor:
@@ -37,7 +44,7 @@ class TorchFn(Fn, abc.ABC):
         raise NotImplementedError
 
 
-class TorchThunk(Thunk, TorchFn):
+class TorchDispatchThunk(Thunk, TorchFn):
     def __init__(
         self,
         func: cabc.Callable[..., typing.Any],
@@ -47,12 +54,18 @@ class TorchThunk(Thunk, TorchFn):
         **kwargs: typing.Any,
     ) -> None:
         Thunk.__init__(self, func, *args, **kwargs)
+        TorchFn.__init__(self)
         self._types = types
 
     @typing.override
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, TorchThunk):
-            return Thunk.__eq__(self, other) and self.types == other.types
+        if isinstance(other, TorchDispatchThunk):
+            return (
+                True
+                and Thunk.__eq__(self, other)
+                and self.types == other.types
+                and self._torch_function == other._torch_function
+            )
 
         if isinstance(other, Thunk):
             return other == self
@@ -95,6 +108,9 @@ class Preview(TorchFn, abc.ABC):
 
     def __init_subclass__(cls) -> None:
         cls.__register_preview()
+
+    def __post_init__(self):
+        TorchFn.__init__(self)
 
     @typing.override
     def __repr__(self) -> str:

--- a/src/aioway/fn/ops/fn.py
+++ b/src/aioway/fn/ops/fn.py
@@ -24,7 +24,7 @@ _PREVIEW_CANDIDATES: dict[_ops.OpOverload, list[cabc.Callable[..., Preview]]] = 
 class TorchFn(Fn, abc.ABC):
     @abc.abstractmethod
     @typing.override
-    def __call__(self) -> torch.Tensor:
+    def do(self) -> torch.Tensor:
         raise NotImplementedError
 
     def parameters(self, select: TensorFilter = all_tensors, /):
@@ -109,7 +109,7 @@ class Preview(TorchFn, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __call__(self) -> torch.Tensor:
+    def do(self) -> torch.Tensor:
         """
         Generate the fake tensor.
         """

--- a/src/aioway/fn/ops/modes.py
+++ b/src/aioway/fn/ops/modes.py
@@ -13,11 +13,12 @@ from torch.utils import _python_dispatch as pyd
 
 from aioway._common.tracking.logging import enable_rich_log
 from aioway.ctx import enabled_fake_mode, fake_mode
+from aioway.fn.funcs import track_function_fn
 from aioway.schemas.attrs import attr
 
-from ..fn import Fn, Thunk
+from ..fn import Fn, FnStack, Thunk
 from ..guards import TensorFilter, all_tensors, is_aten_op, is_leaf_has_grad, is_prim_op
-from .fn import Preview, TorchFn, TorchThunk, find_preview
+from .fn import Preview, TorchDispatchThunk, TorchFn, find_preview
 
 __all__ = [
     "print_torch_dispatch",
@@ -35,9 +36,7 @@ LOGGER = logging.getLogger(__name__)
 _CreatePreview = cabc.Callable[..., Preview]
 _TorchRouterMode = typing.Literal["dispatch", "function"]
 
-
-_active_dispatch: Fn | None = None
-"The current dispatch."
+_DISPATCH_STACK = FnStack[TorchFn]()
 
 
 @typing.runtime_checkable
@@ -140,6 +139,12 @@ class FnList:
     """
 
     history: list[TorchFn] = dcls.field(default_factory=list)
+    """
+    The `TorchFn` that has been called, in order.
+    """
+
+    fn_index: dict[torch.Tensor, TorchFn] = dcls.field(default_factory=dict)
+    "The mapping from output to tensor input."
 
     def __len__(self) -> int:
         return len(self.history)
@@ -174,6 +179,9 @@ class FnList:
     def memory(self) -> int:
         return sum(attr(param).memory() for param in self.parameters(all_tensors))
 
+    def find_fn(self, tensor: torch.Tensor):
+        return self.fn_index[tensor]
+
 
 @dcls.dataclass
 class TrackDispatchMode(pyd.TorchDispatchMode):
@@ -200,18 +208,17 @@ class TrackDispatchMode(pyd.TorchDispatchMode):
             # Fn is not handled.
             or (fn := fn_init(*args, **kwargs)) is NotImplemented
         ):
-            fn = TorchThunk(func, types, *args, **kwargs)
+            fn = TorchDispatchThunk(func, types, *args, **kwargs)
 
         assert isinstance(fn, TorchFn), fn
         self.history.append(fn)
 
-        try:
-            # Ensure that only 1 dispatch is running at any given moment.
-            with _ensure_single_dispatch(fn):
-                return fn.do()
-        except RuntimeError as err:
-            fn = TorchThunk(func, types, *args, **kwargs)
-            raise ValueError(f"Function call '{fn}' failed.") from err
+        with _DISPATCH_STACK.track(fn), capture_do_error(fn):
+            result = fn.do()
+
+        # Store it in the history.
+        self.history.fn_index[result] = fn
+        return result
 
 
 def aten_ops_preview(
@@ -222,12 +229,20 @@ def aten_ops_preview(
 
 
 @ctxl.contextmanager
-def track_dispatch_fn():
+def capture_do_error(fn: TorchFn):
+    try:
+        yield
+    except RuntimeError as err:
+        raise ValueError(f"Function call '{fn}' failed.") from err
+
+
+@ctxl.contextmanager
+def track_dispatch_fn(router: TorchRouterFactory = no_route):
     """
     Track all calls into the torch dispatch mode as `TorchIrFn`.
     """
 
-    with TrackDispatchMode(router=no_route) as sdm:
+    with track_function_fn(), TrackDispatchMode(router=router) as sdm:
         yield sdm.history
 
 
@@ -238,25 +253,9 @@ def fake_dispatch_fn():
     when fake mode is active.
     """
 
-    with fake_mode(), TrackDispatchMode(router=only_route_aten_in_fake) as sdm:
-        yield sdm.history
+    with fake_mode(), track_dispatch_fn(only_route_aten_in_fake) as history:
+        yield history
 
 
-@ctxl.contextmanager
-def _ensure_single_dispatch(fn: Fn):
-    "Ensure that only 1 dispatch is running at any given moment."
-
-    global _active_dispatch
-
-    if _active_dispatch is not None:
-        raise ValueError("Cannot run 2 dispatches at once.")
-
-    try:
-        _active_dispatch = fn
-        yield
-    finally:
-        _active_dispatch = None
-
-
-def active_dispatch():
-    return _active_dispatch
+def torch_dispatch_stack():
+    return _DISPATCH_STACK

--- a/src/aioway/fn/ops/modes.py
+++ b/src/aioway/fn/ops/modes.py
@@ -67,7 +67,10 @@ class _PrintDispatch(pyd.TorchDispatchMode):
     ):
         kwargs = kwargs or {}
         invoke = Thunk(func, *args, **kwargs)
-        result = invoke()
+        return self.invoke_and_print(invoke)
+
+    def invoke_and_print(self, invoke: Thunk):
+        result = invoke.do()
         print(f"{invoke!s} -> {result!r}")
         return result
 
@@ -79,7 +82,7 @@ Print the dispatcher.
 
 
 @dcls.dataclass
-class _LogDispatch(pyd.TorchDispatchMode):
+class _LogDispatch(_PrintDispatch):
     """
     Log every call to dispatch mode.
     """
@@ -90,16 +93,9 @@ class _LogDispatch(pyd.TorchDispatchMode):
     logger: logging.Logger = LOGGER
     "The logger to log to. Default to the one in the current module."
 
-    def __torch_dispatch__(
-        self,
-        func: _ops.OpOverload,
-        types: tuple[type[torch.Tensor], ...],
-        args: tuple[typing.Any, ...] = (),
-        kwargs: dict[str, typing.Any] | None = None,
-    ):
-        kwargs = kwargs or {}
-        invoke = Thunk(func, *args, **kwargs)
-        result = invoke()
+    @typing.override
+    def invoke_and_print(self, invoke: Thunk):
+        result = invoke.do()
         self.logger.log(self.level, f"%s -> %s", invoke, result)
         return result
 
@@ -139,6 +135,10 @@ def no_route(*args, **kwargs) -> _CreatePreview:
 
 @dcls.dataclass(frozen=True)
 class FnList:
+    """
+    The list of `TorchFn` that tracks the current history.
+    """
+
     history: list[TorchFn] = dcls.field(default_factory=list)
 
     def __len__(self) -> int:
@@ -208,7 +208,7 @@ class TrackDispatchMode(pyd.TorchDispatchMode):
         try:
             # Ensure that only 1 dispatch is running at any given moment.
             with _ensure_single_dispatch(fn):
-                return fn()
+                return fn.do()
         except RuntimeError as err:
             fn = TorchThunk(func, types, *args, **kwargs)
             raise ValueError(f"Function call '{fn}' failed.") from err


### PR DESCRIPTION
Improved `Fn` and `__torch_function__` `__torch_dispatch__` interaction. Torch dispatch calls now carry their torch function as cotnext.

Improve `Fn` from their output `Tensor`, will allow us to reversly reconstruct the graph after the fact.

Fix #185.