### PR TITLE
Refine tags and fake audio mode

### DIFF
--- a/notebooks/tags.py
+++ b/notebooks/tags.py
@@ -1,0 +1,41 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import torch
+
+# %%
+from aioway.tags import SampleRateTag
+
+# %%
+t = torch.randn(3, 4)
+
+# %%
+sr = SampleRateTag(t, 100)
+
+# %%
+s = torch.randn(4, 5)
+
+# %%
+sr.attach(s)
+
+# %%
+SampleRateTag.extract(t)
+
+# %%
+SampleRateTag.extract(s)
+
+# %%
+SampleRateTag.extract(t) == SampleRateTag.extract(s)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "build", "debugging", "networkx", "pre-commit", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:178471560ff9d7f0540362d99013a2c707605311c560c2f8cf9d85b94b54061a"
+content_hash = "sha256:44731b2ccf6741e981002c819557d52cf2e813d07ebc6b696324dabf9e6adf0b"
 
 [[metadata.targets]]
 requires_python = ">=3.14,<3.15"
@@ -162,6 +162,32 @@ dependencies = [
 files = [
     {file = "autoflake-2.3.3-py3-none-any.whl", hash = "sha256:a51a3412aff16135ee5b3ec25922459fef10c1f23ce6d6c4977188df859e8b53"},
     {file = "autoflake-2.3.3.tar.gz", hash = "sha256:c24809541e23999f7a7b0d2faadf15deb0bc04cdde49728a2fd943a0c8055504"},
+]
+
+[[package]]
+name = "av"
+version = "17.0.1"
+requires_python = ">=3.10"
+summary = "Pythonic bindings for FFmpeg's libraries."
+groups = ["default"]
+files = [
+    {file = "av-17.0.1-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:987f4f46ceae4da6c614dcbd2b8149be9dbf680c3bb7a6841c58af9cff4d9230"},
+    {file = "av-17.0.1-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:d97f54e55b18a74912f479c1978aadd1341d38d892dee95bb5c2f2dccfa72f32"},
+    {file = "av-17.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e6eee84afa48d0e9321047cd3e4facd44b401493f6bdc753e2e1d1e7c9e6d13e"},
+    {file = "av-17.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c58c71bffd9383908c85695ac61d3184c668accb04a5bd1b262e0fb8d09f60a5"},
+    {file = "av-17.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:42d6745d30a410ec9b22aef79a52a7ab5a001eb8f5adfd952946606a30983318"},
+    {file = "av-17.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3ed6bcd7021fe55832f95b8ef78dd01a4cb21faf3cd71f1e1bf4f20bf100b278"},
+    {file = "av-17.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:9af524e8632a54032e361d6b88895bd3e7c6212ca560de60f5ccc525323c764c"},
+    {file = "av-17.0.1-cp311-abi3-win_arm64.whl", hash = "sha256:50e58a473d65ea29b645e45c9fd8518a6783737135683ecc40571a91592bdfe4"},
+    {file = "av-17.0.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:1d33871742d1e71562db3c8e752cacc5a62766d7efc3ae408bff1c3e26ebb46e"},
+    {file = "av-17.0.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:1229e879f4b6431bc00f69d7f8891fe9a683b0a6e0e009e6c98eb7e449f0383d"},
+    {file = "av-17.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4744837f4116964280bcc72285e3cdd51361e98a696205aadd924203440ef511"},
+    {file = "av-17.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3d0a7d45d9599bf9df9f8249827113d4f36df1cd6b5356227b997f0552dbc98e"},
+    {file = "av-17.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9acd0b6a6e02af2b37f63d97a03ee2c47936d58e82425c3cd075a95245937c59"},
+    {file = "av-17.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3d3a36204cb1f1e7691e6446afa8d6b7097b09946dae732c71c5d05ce09e506e"},
+    {file = "av-17.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:b87b98afe971cde123953073bc9c95ab0b7efd2ecc082dd2dbd11f9d9abf190e"},
+    {file = "av-17.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:a87a42c36e29f75e7dff7281944f2a6876a2c8875e225ccbf6c1ae62748b4caa"},
+    {file = "av-17.0.1.tar.gz", hash = "sha256:fbcbd4aa43bca6a8691816283112d1659a27f407bbeb66d1397023691339f5d4"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.14,<3.15"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 dynamic = ["version"]
-dependencies = ["numpy>=2.4.3", "pandas>=3.0.1", "rich>=14.3.3", "tensordict>=0.11.0", "torch==2.10.*", "torchvision>=0.25.0", "torchcodec==0.10.*", "pillow>=12.2.0"]
+dependencies = ["numpy>=2.4.3", "pandas>=3.0.1", "rich>=14.3.3", "tensordict>=0.11.0", "torch==2.10.*", "torchvision>=0.25.0", "torchcodec==0.10.*", "pillow>=12.2.0", "av>=17.0.1"]
 
 [project.optional-dependencies]
 networkx = [
@@ -81,7 +81,7 @@ check_untyped_defs = true
 [[tool.mypy.overrides]]
 module = [
     "tensordict.*",
-    "faiss.*",
+    "soundfile.*",
     "torchvision.*",
     "torchcodec.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ check_untyped_defs = true
 [[tool.mypy.overrides]]
 module = [
     "tensordict.*",
-    "soundfile.*",
     "torchvision.*",
     "torchcodec.*",
 ]

--- a/src/aioway/_common/types.py
+++ b/src/aioway/_common/types.py
@@ -9,6 +9,7 @@ __all__ = [
     "dcls_no_eq",
     "dcls_no_repr",
     "dcls_frozen_no_repr",
+    "dcls_frozen_slots_no_eq",
     "dcls_no_eq_no_repr",
     "Stack",
 ]
@@ -17,6 +18,12 @@ __all__ = [
 @typing.dataclass_transform(eq_default=False)
 def dcls_no_eq[T: type](cls: T) -> T:
     result: typing.Any = dcls.dataclass(eq=False)(cls)
+    return result
+
+
+@typing.dataclass_transform(eq_default=False, frozen_default=True)
+def dcls_frozen_slots_no_eq[T: type](cls: T) -> T:
+    result: typing.Any = dcls.dataclass(eq=False, frozen=True, slots=True)(cls)
     return result
 
 

--- a/src/aioway/io/__init__.py
+++ b/src/aioway/io/__init__.py
@@ -2,5 +2,6 @@
 
 from .audios import *
 from .images import *
+from .io import *
 from .texts import *
 from .videos import *

--- a/src/aioway/io/audios.py
+++ b/src/aioway/io/audios.py
@@ -1,45 +1,55 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-import os
+import pathlib
 import typing
 
 import torch
 from torchcodec import decoders as dec
 
 from aioway.fake import torch_enable_fake_mode_func
+from aioway.tags import SampleRateTag
 
-__all__ = ["AudioData", "read_audio_from_path"]
+from .io import AudioLoader
 
-
-class AudioData(typing.Protocol):
-    data: torch.Tensor
-    "The sample data, [num channels, num samples]."
-
-    sample_rate: int
-    "The sample rate in Hz."
+__all__ = ["TorchCodecAudioLoader"]
 
 
-@torch_enable_fake_mode_func(False)
-def read_audio_from_path(
-    fname: os.PathLike[str], sample_rate: int | None = None
-) -> AudioData:
+def encode_with_stft(audio: torch.Tensor, /, n_fft: int) -> torch.Tensor:
     """
-    Read and decode audio from path.
-
-    Args:
-        fname: The file location.
-        sample_rate:
-            The sample rate in Hz.
-            If given, this should be equal to the sample rate in return value.
+    Encode the audio with `torch.stft`. Naturally works with fake mode.
     """
 
-    decoder = dec.AudioDecoder(str(fname), sample_rate=sample_rate)
-    samples = decoder.get_all_samples()
+    result = torch.stft(audio, n_fft, return_complex=True)
+    SampleRateTag.extract(audio)
+    return result.real
 
-    if sample_rate and sample_rate != samples.sample_rate:
-        raise AssertionError(
-            f"The configured sample rates {sample_rate} "
-            f"and output {samples.sample_rate} should be equal."
-        )
 
-    return samples
+class TorchCodecAudioLoader(AudioLoader):
+
+    @typing.override
+    def load_wave(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        return self._read_audio_from_path(fname)
+
+    @torch_enable_fake_mode_func(False)
+    def _read_audio_from_path(self, fname: str | pathlib.Path) -> torch.Tensor:
+        """
+        Read and decode audio from path.
+
+        Args:
+            fname: The file location.
+            sample_rate:
+                The sample rate in Hz.
+                If given, this should be equal to the sample rate in return value.
+        """
+
+        decoder = dec.AudioDecoder(str(fname), sample_rate=self.sample_rate)
+        samples = decoder.get_all_samples()
+
+        if self.sample_rate and self.sample_rate != samples.sample_rate:
+            raise AssertionError(
+                f"The configured sample rates {self.sample_rate} "
+                f"and output {samples.sample_rate} should be equal."
+            )
+
+        _ = SampleRateTag(samples.data, samples.sample_rate)
+        return samples.data

--- a/src/aioway/io/audios.py
+++ b/src/aioway/io/audios.py
@@ -37,7 +37,8 @@ class AvAudioLoader(AudioLoader):
         stream = container.streams.audio[0]
         sample_rate = stream.codec_context.sample_rate
         channels = stream.codec_context.channels
-        frames = stream.frames
+        assert stream.duration
+        frames = stream.duration * stream.sample_rate
 
         # Create a fake tensor of float32 in fake mode.
         if enabled_fake_mode():

--- a/src/aioway/io/audios.py
+++ b/src/aioway/io/audios.py
@@ -3,15 +3,18 @@
 import pathlib
 import typing
 
+import av
+import numpy as np
 import torch
 from torchcodec import decoders as dec
 
-from aioway.fake import torch_enable_fake_mode_func
+from aioway.fake import enabled_fake_mode, torch_enable_fake_mode_func
+from aioway.schemas import Attr
 from aioway.tags import SampleRateTag
 
 from .io import AudioLoader
 
-__all__ = ["TorchCodecAudioLoader"]
+__all__ = ["AvAudioLoader", "TorchCodecAudioLoader"]
 
 
 def encode_with_stft(audio: torch.Tensor, /, n_fft: int) -> torch.Tensor:
@@ -22,6 +25,39 @@ def encode_with_stft(audio: torch.Tensor, /, n_fft: int) -> torch.Tensor:
     result = torch.stft(audio, n_fft, return_complex=True)
     SampleRateTag.extract(audio)
     return result.real
+
+
+class AvAudioLoader(AudioLoader):
+    "Load the audio with `av` library."
+
+    @typing.override
+    def load_wave(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        container = av.open(fname)
+
+        stream = container.streams.audio[0]
+        sample_rate = stream.codec_context.sample_rate
+        channels = stream.codec_context.channels
+        frames = stream.frames
+
+        # Create a fake tensor of float32 in fake mode.
+        if enabled_fake_mode():
+            tensor = Attr.parse(
+                shape=[channels, frames], dtype=torch.float32
+            ).to_fake_tensor()
+
+        else:
+            chunks: list[np.ndarray] = []
+            for frame in container.decode(stream):
+                arr = frame.to_ndarray()
+                assert arr.ndim == 2
+                assert len(arr) == channels
+                chunks.append(arr)
+
+            array = np.concat(chunks, axis=1)
+            tensor = torch.tensor(array)
+
+        _ = SampleRateTag(tensor, sample_rate)
+        return tensor
 
 
 class TorchCodecAudioLoader(AudioLoader):

--- a/src/aioway/io/audios.py
+++ b/src/aioway/io/audios.py
@@ -23,8 +23,13 @@ def encode_with_stft(audio: torch.Tensor, /, n_fft: int) -> torch.Tensor:
     """
 
     result = torch.stft(audio, n_fft, return_complex=True)
-    SampleRateTag.extract(audio)
-    return result.real
+    real_result = result.real
+
+    # Perhaps we should handle tags passing in `Fate`.
+    if tag := SampleRateTag.extract(audio):
+        tag.attach(real_result)
+
+    return real_result
 
 
 class AvAudioLoader(AudioLoader):

--- a/src/aioway/io/audios.py
+++ b/src/aioway/io/audios.py
@@ -34,10 +34,11 @@ class AvAudioLoader(AudioLoader):
     def load_wave(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         container = av.open(fname)
 
+        # Get the metadata for fake mode to work.
         stream = container.streams.audio[0]
         sample_rate = stream.codec_context.sample_rate
         channels = stream.codec_context.channels
-        assert stream.duration
+        assert stream.duration, "Duration should exist, this is not a stream!"
         frames = stream.duration * stream.sample_rate
 
         # Create a fake tensor of float32 in fake mode.
@@ -46,6 +47,7 @@ class AvAudioLoader(AudioLoader):
                 shape=[channels, frames], dtype=torch.float32
             ).to_fake_tensor()
 
+        # Decode frame by frame.
         else:
             chunks: list[np.ndarray] = []
             for frame in container.decode(stream):

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -41,7 +41,7 @@ class ComposedImageLoader(ImageLoader):
     """
 
     @typing.override
-    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load_img(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         tensor = self.loader(fname)
         return self.transform(tensor)
 
@@ -56,7 +56,7 @@ class PillowImageLoader(ImageLoader):
     "The transform to use to convert the pillow image to a tensor."
 
     @typing.override
-    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load_img(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         img = image.open(fname)
         return self.transform(img)
 
@@ -64,7 +64,7 @@ class PillowImageLoader(ImageLoader):
 @dcls.dataclass
 class FakePillowImageLoader(ImageLoader):
     @typing.override
-    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load_img(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         img = image.open(fname)
 
         # Convert to `uint8` as a hack, because we don't support it in our dtypes.
@@ -89,7 +89,7 @@ class TvioImageLoader(ImageLoader):
     "If `True`, normalize the `uint8` tensor to 0-1 `float` tensor."
 
     @typing.override
-    def load(self, fname: str | pathlib.Path):
+    def load_img(self, fname: str | pathlib.Path):
         reader = self._read_normalized if self.norm else self._read_image
         return reader(fname)
 

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -41,7 +41,7 @@ class ComposedImageLoader(ImageLoader):
     """
 
     @typing.override
-    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         tensor = self.loader(fname)
         return self.transform(tensor)
 
@@ -56,7 +56,7 @@ class PillowImageLoader(ImageLoader):
     "The transform to use to convert the pillow image to a tensor."
 
     @typing.override
-    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         img = image.open(fname)
         return self.transform(img)
 
@@ -64,7 +64,7 @@ class PillowImageLoader(ImageLoader):
 @dcls.dataclass
 class FakePillowImageLoader(ImageLoader):
     @typing.override
-    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         img = image.open(fname)
 
         # Convert to `uint8` as a hack, because we don't support it in our dtypes.
@@ -78,7 +78,7 @@ class FakePillowImageLoader(ImageLoader):
 
 
 @dcls.dataclass
-class TvioImageLoader:
+class TvioImageLoader(ImageLoader):
     """
     The loader backed by `torchvision.io`. It should be faster than the PIL route.
 
@@ -88,7 +88,8 @@ class TvioImageLoader:
     norm: bool = False
     "If `True`, normalize the `uint8` tensor to 0-1 `float` tensor."
 
-    def __call__(self, fname: str | pathlib.Path):
+    @typing.override
+    def load(self, fname: str | pathlib.Path):
         reader = self._read_normalized if self.norm else self._read_image
         return reader(fname)
 

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -1,6 +1,5 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-import abc
 import dataclasses as dcls
 import pathlib
 import typing
@@ -13,22 +12,14 @@ from torchvision.transforms import v2 as tt
 from aioway.fake import torch_enable_fake_mode_func
 from aioway.schemas import attr
 
+from .io import ImageLoader
+
 __all__ = [
-    "ImageLoader",
     "ComposedImageLoader",
     "PillowImageLoader",
     "FakePillowImageLoader",
     "TvioImageLoader",
 ]
-
-
-@dcls.dataclass
-class ImageLoader(abc.ABC):
-    "The image loader API. Converts from a file name `fname` to a tensor."
-
-    @abc.abstractmethod
-    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
-        raise NotImplementedError
 
 
 @dcls.dataclass

--- a/src/aioway/io/io.py
+++ b/src/aioway/io/io.py
@@ -56,6 +56,7 @@ class AudioLoader(FileLoader, abc.ABC):
         if SampleRateTag.extract(audio) is None:
             raise AssertionError(f"Forgot to tag the audio tensor with sample rate.")
 
+        assert audio.ndim == 2, audio.shape
         return audio
 
     @abc.abstractmethod

--- a/src/aioway/io/io.py
+++ b/src/aioway/io/io.py
@@ -8,6 +8,7 @@ import typing
 import torch
 
 from aioway.tags import IsImageTag
+from aioway.tags.media import SampleRateTag
 
 
 @dcls.dataclass
@@ -34,4 +35,29 @@ class ImageLoader(FileLoader, abc.ABC):
 
     @abc.abstractmethod
     def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        raise NotImplementedError
+
+
+@dcls.dataclass
+class AudioLoader(FileLoader, abc.ABC):
+    """
+    The audio loader API. Load the data into wave.
+    Result is tensor [num_channels, num_frames].
+    """
+
+    sample_rate: int | None = None
+    "The specified sample rate. If `None` the default would be loaded."
+
+    @typing.override
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        audio = self.load_wave(fname)
+
+        # Ensure it's actually tagged.
+        if SampleRateTag.extract(audio) is None:
+            raise AssertionError(f"Forgot to tag the audio tensor with sample rate.")
+
+        return audio
+
+    @abc.abstractmethod
+    def load_wave(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         raise NotImplementedError

--- a/src/aioway/io/io.py
+++ b/src/aioway/io/io.py
@@ -1,0 +1,28 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+import abc
+import pathlib
+
+import torch
+
+__all__ = ["FileLoader", "ImageLoader", "AudioWaveLoader", "AudioFreqLoader"]
+
+
+class FileLoader(abc.ABC):
+    "The common file loader interface."
+
+    @abc.abstractmethod
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class ImageLoader(FileLoader, abc.ABC):
+    "The image loader API. Converts from a file name `fname` to a tensor."
+
+
+class AudioWaveLoader(FileLoader, abc.ABC):
+    "The audio loader in wave form."
+
+
+class AudioFreqLoader(FileLoader, abc.ABC):
+    "The audio loader in frequency form."

--- a/src/aioway/io/io.py
+++ b/src/aioway/io/io.py
@@ -26,7 +26,7 @@ class ImageLoader(FileLoader, abc.ABC):
 
     @typing.override
     def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
-        data = self.load(fname)
+        data = self.load_img(fname)
 
         # Attach the tag onto the tensor.
         _ = IsImageTag(data)
@@ -34,7 +34,7 @@ class ImageLoader(FileLoader, abc.ABC):
         return data
 
     @abc.abstractmethod
-    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+    def load_img(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         raise NotImplementedError
 
 

--- a/src/aioway/io/io.py
+++ b/src/aioway/io/io.py
@@ -1,28 +1,37 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 import abc
+import dataclasses as dcls
 import pathlib
+import typing
 
 import torch
 
-__all__ = ["FileLoader", "ImageLoader", "AudioWaveLoader", "AudioFreqLoader"]
+from aioway.tags import IsImageTag
 
 
+@dcls.dataclass
 class FileLoader(abc.ABC):
-    "The common file loader interface."
+    "The base loader API."
 
     @abc.abstractmethod
     def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
         raise NotImplementedError
 
 
+@dcls.dataclass
 class ImageLoader(FileLoader, abc.ABC):
     "The image loader API. Converts from a file name `fname` to a tensor."
 
+    @typing.override
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        data = self.load(fname)
 
-class AudioWaveLoader(FileLoader, abc.ABC):
-    "The audio loader in wave form."
+        # Attach the tag onto the tensor.
+        _ = IsImageTag(data)
 
+        return data
 
-class AudioFreqLoader(FileLoader, abc.ABC):
-    "The audio loader in frequency form."
+    @abc.abstractmethod
+    def load(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        raise NotImplementedError

--- a/src/aioway/might/containers.py
+++ b/src/aioway/might/containers.py
@@ -4,8 +4,9 @@ import typing
 
 from torch import nn
 
-from .might import Might
 from aioway._common import dcls_no_repr
+
+from .might import Might
 
 __all__ = ["Sequential"]
 

--- a/src/aioway/tags/__init__.py
+++ b/src/aioway/tags/__init__.py
@@ -1,3 +1,5 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 from .dims import *
+from .media import *
+from .tags import *

--- a/src/aioway/tags/audios.py
+++ b/src/aioway/tags/audios.py
@@ -21,5 +21,7 @@ class SampleRateTag(Tag):
     """
 
     def __post_init__(self):
+        super().__post_init__()
+
         if self.sample_rate <= 0:
             raise ValueError(f"{self.sample_rate} <= 0.")

--- a/src/aioway/tags/dims.py
+++ b/src/aioway/tags/dims.py
@@ -6,18 +6,10 @@ import dataclasses as dcls
 import enum
 import functools
 import re
-import typing
 
-import torch
+from .tags import Tag
 
-from aioway.fake import is_fake_tensor
-
-__all__ = ["set_dim_tag", "get_dim_tag", "check_dim_tag", "DimTag"]
-
-
-@typing.runtime_checkable
-class HasDimTag(typing.Protocol):
-    __aioway_dim_tag__: DimTag
+__all__ = ["DimTag", "DimInfo"]
 
 
 class DimInfo(enum.StrEnum):
@@ -51,10 +43,9 @@ class DimInfo(enum.StrEnum):
     """
 
 
-@dcls.dataclass(frozen=True)
-class DimTag:
-    tensor: torch.Tensor
-    "The tensor that is being piggy backed."
+@dcls.dataclass(frozen=True, slots=True)
+class DimTag(Tag):
+    TAG = "__aioway_dim_tag__"
 
     tags: str
     """
@@ -63,40 +54,18 @@ class DimTag:
     """
 
     def __post_init__(self) -> None:
+        super().__post_init__()
+
         if len(self.tags) != (ndim := self.ndim):
             raise ValueError(
                 f"The {self.tags=} dimensions do not match the tensor's {ndim=}."
             )
 
-    @property
-    def ndim(self) -> int:
-        return self.tensor.ndim
-
-    @property
-    def is_fake(self) -> bool:
-        return is_fake_tensor(self.tensor)
+        if not _valid_dim_tag(self.tags):
+            raise ValueError("The dimension tags are not valid.")
 
 
-def set_dim_tag(tensor: torch.Tensor, tag: str):
-    "Tag the `torch.Tensor` with the given tag."
-
-    def _cast_tensor(t: typing.Any) -> HasDimTag:
-        return t
-
-    dim_tag = DimTag(tensor, tag)
-    tagged = _cast_tensor(tensor)
-    tagged.__aioway_dim_tag__ = dim_tag
-
-
-def get_dim_tag(tensor: torch.Tensor) -> DimTag | None:
-    if isinstance(tensor, HasDimTag):
-        return tensor.__aioway_dim_tag__
-
-    else:
-        return None
-
-
-def check_dim_tag(tags: str) -> bool:
+def _valid_dim_tag(tags: str) -> bool:
     return _valid_regex().fullmatch(tags) is not None
 
 

--- a/src/aioway/tags/dims.py
+++ b/src/aioway/tags/dims.py
@@ -2,10 +2,11 @@
 
 "Extra information about the tensors."
 
-import dataclasses as dcls
 import enum
 import functools
 import re
+
+from aioway._common import dcls_frozen_slots_no_eq
 
 from .tags import Tag
 
@@ -43,7 +44,7 @@ class DimInfo(enum.StrEnum):
     """
 
 
-@dcls.dataclass(frozen=True, slots=True)
+@dcls_frozen_slots_no_eq
 class DimTag(Tag):
     TAG = "__aioway_dim_tag__"
 

--- a/src/aioway/tags/media.py
+++ b/src/aioway/tags/media.py
@@ -2,10 +2,9 @@
 
 "Extra information about the tensors."
 
-import dataclasses as dcls
-
 import torch
 
+from aioway._common import dcls_frozen_slots_no_eq
 from aioway.fake import is_fake_tensor
 from aioway.schemas import DType
 
@@ -14,7 +13,7 @@ from .tags import Tag
 __all__ = ["IsImageTag", "SampleRateTag"]
 
 
-@dcls.dataclass(frozen=True, slots=True)
+@dcls_frozen_slots_no_eq
 class IsImageTag(Tag):
     """
     Tag the tensor as image. Should be 4 dimensional.
@@ -24,6 +23,7 @@ class IsImageTag(Tag):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+
         self._check_ndim()
         self._check_value()
 
@@ -57,7 +57,7 @@ class IsImageTag(Tag):
         )
 
 
-@dcls.dataclass(frozen=True, slots=True)
+@dcls_frozen_slots_no_eq
 class SampleRateTag(Tag):
     """
     Tag the tensor as audio, and having a sample rate.
@@ -71,5 +71,7 @@ class SampleRateTag(Tag):
     """
 
     def __post_init__(self):
+        super().__post_init__()
+
         if self.sample_rate <= 0:
             raise ValueError(f"{self.sample_rate} <= 0.")

--- a/src/aioway/tags/media.py
+++ b/src/aioway/tags/media.py
@@ -1,0 +1,75 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+"Extra information about the tensors."
+
+import dataclasses as dcls
+
+import torch
+
+from aioway.fake import is_fake_tensor
+from aioway.schemas import DType
+
+from .tags import Tag
+
+__all__ = ["IsImageTag", "SampleRateTag"]
+
+
+@dcls.dataclass(frozen=True, slots=True)
+class IsImageTag(Tag):
+    """
+    Tag the tensor as image. Should be 4 dimensional.
+    """
+
+    TAG = "__aioway_is_image__"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._check_ndim()
+        self._check_value()
+
+    def _check_ndim(self):
+        if self.tensor.ndim not in [3, 4]:
+            raise ValueError(
+                f"The tensor has ndim={self.tensor.ndim}!=3,4. Should be [B]CWH."
+            )
+
+    def _check_value(self):
+        dtype = DType.parse(self.tensor.dtype)
+
+        if dtype == torch.uint8:
+            return
+
+        # If fake mode then ok.
+        if dtype.is_floating_point and is_fake_tensor(self.tensor):
+            return
+
+        def is_0_to_1():
+            return (
+                torch.all(0 <= self.tensor).item() and torch.all(self.tensor < 1).item()
+            )
+
+        if dtype.is_floating_point and is_0_to_1():
+            return
+
+        raise ValueError(
+            f"The tensor with {dtype=} is not valid! "
+            "Should be an uint8 tensor, or a floating point tensor with 0-1 values."
+        )
+
+
+@dcls.dataclass(frozen=True, slots=True)
+class SampleRateTag(Tag):
+    """
+    Tag the tensor as audio, and having a sample rate.
+    """
+
+    TAG = "__aioway_audio_sample_rate__"
+
+    sample_rate: int
+    """
+    The sample rate. Must be positive.
+    """
+
+    def __post_init__(self):
+        if self.sample_rate <= 0:
+            raise ValueError(f"{self.sample_rate} <= 0.")

--- a/src/aioway/tags/tags.py
+++ b/src/aioway/tags/tags.py
@@ -9,6 +9,7 @@ import typing
 
 import torch
 
+from aioway._common import dcls_frozen_slots_no_eq
 from aioway.fake import is_fake_tensor
 
 __all__ = ["Tag", "extract_tags"]
@@ -16,7 +17,7 @@ __all__ = ["Tag", "extract_tags"]
 _TAG_NAME = re.compile(r"^__aioway_[a-zA-Z0-9_]+__$")
 
 
-@dcls.dataclass(frozen=True, slots=True)
+@dcls_frozen_slots_no_eq
 class Tag(abc.ABC):
     """
     The base class for tags. A tag describes a `torch.Tensor`,
@@ -50,6 +51,22 @@ class Tag(abc.ABC):
         # Set the tag onto the tensor.
         setattr(self.tensor, self.TAG, self)
 
+    @typing.override
+    def __eq__(self, other: object):
+        "Comparing 2 tags compare all fields that are not the `.tensor`."
+
+        if type(self) == type(other):
+            assert isinstance(other, Tag)
+            return self._cmp_dict() == other._cmp_dict()
+
+        return NotImplemented
+
+    def _cmp_dict(self):
+        fields = {f.name for f in dcls.fields(self)}
+        base_tag_fields = {f.name for f in dcls.fields(Tag)}
+        to_compare = fields - base_tag_fields
+        return {key: getattr(self, key) for key in to_compare}
+
     @property
     def ndim(self) -> int:
         return self.tensor.ndim
@@ -61,6 +78,21 @@ class Tag(abc.ABC):
     @property
     def is_fake(self) -> bool:
         return is_fake_tensor(self.tensor)
+
+    def tag(self, other: torch.Tensor, /) -> typing.Self:
+        """
+        Tag the instance on another tensor.
+        """
+
+        # In case the same tensor is tagged again.
+        if self.tensor is other:
+            return self
+
+        # Replace the `tensor` attribute,
+        # and call `__post_init__` which handles attribute setting.
+        copied = dcls.replace(self, tensor=other)
+        copied.__post_init__()
+        return copied
 
     @classmethod
     def extract(cls, tensor: torch.Tensor) -> typing.Self | None:

--- a/src/aioway/tags/tags.py
+++ b/src/aioway/tags/tags.py
@@ -92,7 +92,8 @@ class Tag(abc.ABC):
         # and call `__post_init__` which handles attribute setting.
         copied = dcls.replace(self, tensor=other)
         copied.__post_init__()
-        assert copied == self.extract(other)
+        assert copied is self.extract(other)
+        assert self == copied
         return copied
 
     @classmethod

--- a/src/aioway/tags/tags.py
+++ b/src/aioway/tags/tags.py
@@ -79,9 +79,9 @@ class Tag(abc.ABC):
     def is_fake(self) -> bool:
         return is_fake_tensor(self.tensor)
 
-    def tag(self, other: torch.Tensor, /) -> typing.Self:
+    def attach(self, other: torch.Tensor, /) -> typing.Self:
         """
-        Tag the instance on another tensor.
+        Tag the instance on another tensor. These 2 tags would be `==` to each other.
         """
 
         # In case the same tensor is tagged again.
@@ -92,6 +92,7 @@ class Tag(abc.ABC):
         # and call `__post_init__` which handles attribute setting.
         copied = dcls.replace(self, tensor=other)
         copied.__post_init__()
+        assert copied == self.extract(other)
         return copied
 
     @classmethod

--- a/src/aioway/tags/tags.py
+++ b/src/aioway/tags/tags.py
@@ -1,0 +1,97 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+"Extra information about the tensors."
+
+import abc
+import dataclasses as dcls
+import re
+import typing
+
+import torch
+
+from aioway.fake import is_fake_tensor
+
+__all__ = ["Tag", "extract_tags"]
+
+_TAG_NAME = re.compile(r"^__aioway_[a-zA-Z0-9_]+__$")
+
+
+@dcls.dataclass(frozen=True, slots=True)
+class Tag(abc.ABC):
+    """
+    The base class for tags. A tag describes a `torch.Tensor`,
+    and is piggybacked onto the tensor to pass around `torch` APIs.
+
+    Each tag type (subclass) defines a tag name `cls.TAG`,
+    corresponding to the attribute name it is set on the tensor.
+
+    This means each tensor would have 1 tag of the same type,
+    multiple tags would have multiple types. Therefore, an instance of tag
+    is expected to fully describe a tensor in that tag's expertise.
+    For example, a tag about batch dimensino should describe all dimensions at once,
+    because that tag type can only have a singleton on each tensor.
+    """
+
+    TAG: typing.ClassVar[str]
+    """
+    The name of the tag. Must be of the format `__aioway_*__`.
+    """
+
+    tensor: torch.Tensor
+    "The tensor that is being piggybacked."
+
+    def __init_subclass__(cls) -> None:
+        if not _TAG_NAME.fullmatch(cls.TAG):
+            raise ValueError(
+                f"Tag name should be of the format `__aioway_*__`. Got {cls.TAG}."
+            )
+
+    def __post_init__(self) -> None:
+        # Set the tag onto the tensor.
+        setattr(self.tensor, self.TAG, self)
+
+    @property
+    def ndim(self) -> int:
+        return self.tensor.ndim
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.tensor.shape
+
+    @property
+    def is_fake(self) -> bool:
+        return is_fake_tensor(self.tensor)
+
+    @classmethod
+    def extract(cls, tensor: torch.Tensor) -> typing.Self | None:
+        """
+        Get the tag currently stored on the `tensor`.
+        """
+
+        if (tag := getattr(tensor, cls.TAG, None)) is None:
+            return None
+
+        if not isinstance(tag, cls):
+            raise TypeError(f"The tag {tag} is of type {type(tag)}, expected {cls}.")
+
+        return tag
+
+
+def extract_tags(tensor: torch.Tensor, /) -> dict[str, Tag]:
+    """
+    Extract all the tags on the `torch.Tensor`.
+
+    This assumes that no one else uses the `__aioway_*__` namespace. Hopefully.
+    """
+
+    tag_names = [attr_name for attr_name in dir(tensor) if _TAG_NAME.match(attr_name)]
+    return {name: _get_tag(tensor, name) for name in tag_names}
+
+
+def _get_tag(tensor: torch.Tensor, tag_name: str, /) -> Tag:
+    if isinstance(attr := getattr(tensor, tag_name, None), Tag):
+        return attr
+
+    raise AttributeError(
+        f"The attribute '{tag_name}' is either not found or not a tag."
+    )

--- a/tests/io/test_audio.py
+++ b/tests/io/test_audio.py
@@ -38,4 +38,4 @@ def test_read_audio_stft(
     audio = loader(example_audio)
     stft = encode_with_stft(audio, 20)
     assert isinstance(stft, torch.Tensor)
-    # assert SampleRateTag.extract(stft) == SampleRateTag.extract(audio)
+    assert SampleRateTag.extract(stft) == SampleRateTag.extract(audio)

--- a/tests/io/test_audio.py
+++ b/tests/io/test_audio.py
@@ -1,0 +1,31 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+import pathlib
+
+import pytest
+import torch
+
+from aioway.io import AudioLoader, AvAudioLoader, TorchCodecAudioLoader
+from aioway.tags import SampleRateTag
+
+
+def _loaders():
+    yield TorchCodecAudioLoader()
+    yield AvAudioLoader()
+
+
+@pytest.fixture(params=_loaders())
+def loader(request: pytest.FixtureRequest):
+    return request.param
+
+
+def test_read_audio(example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode):
+    audio = loader(example_audio)
+    assert isinstance(audio, torch.Tensor)
+
+
+def test_read_audio_tags(
+    example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode
+):
+    audio = loader(example_audio)
+    assert SampleRateTag.extract(audio) is not None

--- a/tests/io/test_audio.py
+++ b/tests/io/test_audio.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from aioway.io import AudioLoader, AvAudioLoader, TorchCodecAudioLoader
+from aioway.io.audios import encode_with_stft
 from aioway.tags import SampleRateTag
 
 
@@ -29,3 +30,12 @@ def test_read_audio_tags(
 ):
     audio = loader(example_audio)
     assert SampleRateTag.extract(audio) is not None
+
+
+def test_read_audio_stft(
+    example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode
+):
+    audio = loader(example_audio)
+    stft = encode_with_stft(audio, 20)
+    assert isinstance(stft, torch.Tensor)
+    # assert SampleRateTag.extract(stft) == SampleRateTag.extract(audio)

--- a/tests/io/test_audio.py
+++ b/tests/io/test_audio.py
@@ -14,7 +14,7 @@ def _loaders():
     yield AvAudioLoader()
 
 
-@pytest.fixture(params=_loaders())
+@pytest.fixture(params=_loaders(), ids=lambda l: type(l).__name__)
 def loader(request: pytest.FixtureRequest):
     return request.param
 

--- a/tests/io/test_images.py
+++ b/tests/io/test_images.py
@@ -12,6 +12,7 @@ from aioway.io import (
     TvioImageLoader,
 )
 from aioway.io.images import FakePillowImageLoader
+from aioway.tags import IsImageTag, extract_tags
 
 
 @pytest.fixture
@@ -34,18 +35,30 @@ def fake_pillow_image_loader():
     return FakePillowImageLoader()
 
 
-def test_read_image(
-    example_image: pathlib.Path, image_loader: ImageLoader, maybe_fake_mode
-):
+def _read_image(example_image: pathlib.Path, image_loader: ImageLoader) -> torch.Tensor:
     image = image_loader(example_image)
     assert isinstance(image, torch.Tensor)
     assert image.dtype == torch.uint8
+    return image
+
+
+def test_read_image(
+    example_image: pathlib.Path, image_loader: ImageLoader, maybe_fake_mode
+):
+    _ = _read_image(example_image, image_loader)
+
+
+def test_read_image_tags(
+    example_image: pathlib.Path, image_loader: ImageLoader, maybe_fake_mode
+):
+    image = _read_image(example_image, image_loader)
+    tags = extract_tags(image)
+    assert IsImageTag.TAG in tags
+    assert isinstance(tags[IsImageTag.TAG], IsImageTag)
 
 
 def test_read_image_fake(
     example_image: pathlib.Path, fake_pillow_image_loader: ImageLoader, fake_mode
 ):
-    image = fake_pillow_image_loader(example_image)
-    assert isinstance(image, torch.Tensor)
+    image = _read_image(example_image, fake_pillow_image_loader)
     assert is_fake_tensor(image)
-    assert image.dtype == torch.uint8

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -2,9 +2,20 @@
 
 import pathlib
 
+import pytest
 import torch
 
-from aioway.io import read_audio_from_path, read_video_from_path
+from aioway.io import AudioLoader, TorchCodecAudioLoader, read_video_from_path
+from aioway.tags import SampleRateTag
+
+
+def _loaders():
+    yield TorchCodecAudioLoader()
+
+
+@pytest.fixture(params=_loaders())
+def loader(request: pytest.FixtureRequest):
+    return request.param
 
 
 def test_media_exits(media: pathlib.Path):
@@ -17,9 +28,16 @@ def test_example_file_exists(example_file: pathlib.Path):
     assert example_file.is_file()
 
 
-def test_read_audio(example_audio: pathlib.Path, maybe_fake_mode):
-    audio = read_audio_from_path(example_audio)
-    assert isinstance(audio.data, torch.Tensor)
+def test_read_audio(example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode):
+    audio = loader(example_audio)
+    assert isinstance(audio, torch.Tensor)
+
+
+def test_read_audio_tags(
+    example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode
+):
+    audio = loader(example_audio)
+    assert SampleRateTag.extract(audio) is not None
 
 
 def test_read_video(example_video: pathlib.Path, maybe_fake_mode):

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -2,20 +2,9 @@
 
 import pathlib
 
-import pytest
 import torch
 
-from aioway.io import AudioLoader, TorchCodecAudioLoader, read_video_from_path
-from aioway.tags import SampleRateTag
-
-
-def _loaders():
-    yield TorchCodecAudioLoader()
-
-
-@pytest.fixture(params=_loaders())
-def loader(request: pytest.FixtureRequest):
-    return request.param
+from aioway.io import read_video_from_path
 
 
 def test_media_exits(media: pathlib.Path):
@@ -26,18 +15,6 @@ def test_media_exits(media: pathlib.Path):
 def test_example_file_exists(example_file: pathlib.Path):
     assert example_file.exists()
     assert example_file.is_file()
-
-
-def test_read_audio(example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode):
-    audio = loader(example_audio)
-    assert isinstance(audio, torch.Tensor)
-
-
-def test_read_audio_tags(
-    example_audio: pathlib.Path, loader: AudioLoader, maybe_fake_mode
-):
-    audio = loader(example_audio)
-    assert SampleRateTag.extract(audio) is not None
 
 
 def test_read_video(example_video: pathlib.Path, maybe_fake_mode):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -63,7 +63,7 @@ def test_tag_eq(valid_tags: TensorAndTag):
 
     assert not extract_tags(another)
 
-    other_tag = tag.tag(another)
+    other_tag = tag.attach(another)
 
     assert extract_tags(another)
     assert tag is not other_tag

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,35 +1,58 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-import pytest
+import typing
 
-from aioway.tags import check_dim_tag
+import pytest
+import torch
+
+from aioway.tags import DimTag
+from aioway.tags.tags import extract_tags
 
 
 def _valid_tags():
-    yield "pippi"
-    yield "tspi"
-    yield "tppix"
+    yield "pippi", torch.randn(3, 3, 3, 3, 3)
+    yield "tspi", torch.randn(3, 3, 3, 3)
+    yield "tppix", torch.randn(3, 3, 3, 3, 3)
 
 
 def _invalid_tags():
-    yield "hello"
-    yield "ts pi"
-    yield "tax"
+    # Invalid tag.
+    yield "hello", torch.randn(3, 3, 3, 3, 3)
+    yield "ts pi", torch.randn(3, 3, 3, 3, 3)
+    yield "tax", torch.randn(3, 3, 3)
+
+    # Dim mismatch
+    yield "tspi", torch.randn(3, 3)
+    yield "tppix", torch.randn(3, 3)
+
+
+class TensorAndTag(typing.NamedTuple):
+    tag: str
+    tensor: torch.Tensor
 
 
 @pytest.fixture(params=_valid_tags())
 def valid_tags(request: pytest.FixtureRequest):
-    return request.param
+    return TensorAndTag(*request.param)
 
 
 @pytest.fixture(params=_invalid_tags())
 def invalid_tags(request: pytest.FixtureRequest):
-    return request.param
+    return TensorAndTag(*request.param)
 
 
-def test_valid_tags(valid_tags: str):
-    assert check_dim_tag(valid_tags)
+def test_valid_tags(valid_tags: TensorAndTag):
+    _ = DimTag(valid_tags.tensor, valid_tags.tag)
 
 
-def test_invalid_tags(invalid_tags: str):
-    assert not check_dim_tag(invalid_tags)
+def test_invalid_tags(invalid_tags: TensorAndTag):
+    with pytest.raises(ValueError):
+        _ = DimTag(invalid_tags.tensor, invalid_tags.tag)
+
+
+def test_attach(valid_tags: TensorAndTag):
+    tag = DimTag(valid_tags.tensor, valid_tags.tag)
+    assert tag.tensor is valid_tags.tensor
+    assert hasattr(tag.tensor, DimTag.TAG)
+    assert DimTag.extract(valid_tags.tensor) is tag
+    assert extract_tags(valid_tags.tensor) == {DimTag.TAG: tag}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -55,3 +55,16 @@ def test_attach(valid_tags: TensorAndTag):
     assert hasattr(tag.tensor, DimTag.TAG)
     assert DimTag.extract(valid_tags.tensor) is tag
     assert extract_tags(valid_tags.tensor) == {DimTag.TAG: tag}
+
+
+def test_tag_eq(valid_tags: TensorAndTag):
+    tag = DimTag(valid_tags.tensor, valid_tags.tag)
+    another = valid_tags.tensor.clone()
+
+    assert not extract_tags(another)
+
+    other_tag = tag.tag(another)
+
+    assert extract_tags(another)
+    assert tag is not other_tag
+    assert tag == other_tag


### PR DESCRIPTION
Refine how tags interact with classes (`Tag.extract` extracts it).
Added the `FileLoader` interface.
Added a `AvAudioLoader` that uses `av`.

Fix #213