### PR TITLE
`Hop` supporting rebuilding

### DIFF
--- a/src/aioway/hop/funcs.py
+++ b/src/aioway/hop/funcs.py
@@ -2,9 +2,8 @@
 
 "The high level operators that are just torch functions / data."
 
-import copy
-
 import abc
+import copy
 import typing
 from collections import abc as cabc
 

--- a/src/aioway/hop/funcs.py
+++ b/src/aioway/hop/funcs.py
@@ -27,6 +27,10 @@ class TensorHop[T = object](Hop):
     def forward(self) -> T:
         return self.data
 
+    @typing.override
+    def rebuild(self) -> typing.Self:
+        return self
+
 
 @hop_dcls
 class _CatStackHop(Hop, abc.ABC):
@@ -47,8 +51,13 @@ class _CatStackHop(Hop, abc.ABC):
     dim: int = 0
     "The `dim` flag that would be passed to `.function`."
 
+    @typing.override
     def forward(self) -> torch.Tensor:
         return self.FUNCTION(self.tensors, dim=self.dim)
+
+    @typing.override
+    def rebuild(self) -> typing.Self:
+        return self
 
 
 @hop_dcls

--- a/src/aioway/hop/funcs.py
+++ b/src/aioway/hop/funcs.py
@@ -2,6 +2,8 @@
 
 "The high level operators that are just torch functions / data."
 
+import copy
+
 import abc
 import typing
 from collections import abc as cabc
@@ -28,8 +30,8 @@ class TensorHop[T = object](Hop):
         return self.data
 
     @typing.override
-    def rebuild(self) -> typing.Self:
-        return self
+    def _rebuild(self) -> typing.Self:
+        return copy.deepcopy(self)
 
 
 @hop_dcls
@@ -56,8 +58,8 @@ class _CatStackHop(Hop, abc.ABC):
         return self.FUNCTION(self.tensors, dim=self.dim)
 
     @typing.override
-    def rebuild(self) -> typing.Self:
-        return self
+    def _rebuild(self) -> typing.Self:
+        return copy.deepcopy(self)
 
 
 @hop_dcls

--- a/src/aioway/hop/hop.py
+++ b/src/aioway/hop/hop.py
@@ -53,12 +53,18 @@ class Hop(abc.ABC):
 
         raise NotImplementedError
 
-    @abc.abstractmethod
     def rebuild(self):
         """
         Rebuild the current `Hop`. This is useful when you are switching contexts,
         e.g. switching on real mode after configuring the `HopDag` in fake mode.
         """
+
+        copied = self._rebuild()
+        assert copied is not self
+        return copied
+
+    @abc.abstractmethod
+    def _rebuild(self):
 
         raise NotImplementedError
 

--- a/src/aioway/hop/hop.py
+++ b/src/aioway/hop/hop.py
@@ -47,6 +47,19 @@ class Hop(abc.ABC):
 
     @abc.abstractmethod
     def forward(self) -> object:
+        """
+        The forwarding logic. Should invoke dependencies' `__call__` methods.
+        """
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def rebuild(self):
+        """
+        Rebuild the current `Hop`. This is useful when you are switching contexts,
+        e.g. switching on real mode after configuring the `HopDag` in fake mode.
+        """
+
         raise NotImplementedError
 
 

--- a/src/aioway/hop/nn/hop.py
+++ b/src/aioway/hop/nn/hop.py
@@ -4,6 +4,7 @@ import abc
 import typing
 
 from torch import nn
+import dataclasses as dcls
 
 from ..hop import Hop, hop_dcls
 
@@ -15,8 +16,15 @@ __all__ = ["NnHop", "NnLayerHop", "NnLossHop"]
 
 @hop_dcls
 class NnHop(Hop, abc.ABC):
-    config: NnInit
+    nn_init: NnInit
     "The config used to initialize the `Hop`."
+
+    module: nn.Module
+    "The `nn.Module` initialized by `nn_init`."
+
+    def rebuild(self) -> typing.Self:
+        new_module = self.nn_init()
+        return dcls.replace(self, module=new_module)
 
 
 @hop_dcls
@@ -25,9 +33,6 @@ class NnLayerHop(NnHop):
     The `Hop` subclass for normal layers in `nn.Module`s.
     It is a thunk so it has args, kwargs as attributes.
     """
-
-    module: nn.Module
-    "`NnLayerHop` stores the module."
 
     input: Hop
     "The input of the `NnLayerHop`. Should output a `torch.Tensor`."
@@ -47,9 +52,6 @@ class NnLossHop(NnHop):
     The `Hop` subclass for loss functions that are `nn.Module`s.
     """
 
-    loss: nn.Module
-    "`NnLossHop` stores the module."
-
     input: Hop
     "The input of the `NnLossHop`. Should output a `torch.Tensor`."
 
@@ -58,4 +60,4 @@ class NnLossHop(NnHop):
 
     @typing.override
     def forward(self) -> object:
-        return self.loss(self.input(), self.target())
+        return self.module(self.input(), self.target())

--- a/src/aioway/hop/nn/hop.py
+++ b/src/aioway/hop/nn/hop.py
@@ -22,7 +22,8 @@ class NnHop(Hop, abc.ABC):
     module: nn.Module
     "The `nn.Module` initialized by `nn_init`."
 
-    def rebuild(self) -> typing.Self:
+    @typing.override
+    def _rebuild(self) -> typing.Self:
         new_module = self.nn_init()
         return dcls.replace(self, module=new_module)
 

--- a/src/aioway/hop/nn/hop.py
+++ b/src/aioway/hop/nn/hop.py
@@ -1,10 +1,10 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 import abc
+import dataclasses as dcls
 import typing
 
 from torch import nn
-import dataclasses as dcls
 
 from ..hop import Hop, hop_dcls
 

--- a/src/aioway/hop/nn/modules.py
+++ b/src/aioway/hop/nn/modules.py
@@ -82,7 +82,7 @@ def find_nn_init(thunk: NnInitFn, /) -> NnInit | None:
     return nn_init_type(*thunk.args, **thunk.kwargs)
 
 
-def build_nn_hop(thunk: NnInitFn, *args, **kwargs):
+def build_nn_hop(thunk: NnInitFn, *args, **kwargs) -> Hop | None:
     if (nn_init := find_nn_init(thunk)) is None:
         return None
 

--- a/tests/compilers/test_builders.py
+++ b/tests/compilers/test_builders.py
@@ -26,9 +26,9 @@ def test_just_linear(input_space: AttrTag, output_space: AttrTag):
     [tensor_node, linear_node] = built
     assert isinstance(linear_node, NnLayerHop)
     assert isinstance(linear_node.module, nn.Linear)
-    assert isinstance(linear_node.config, Linear)
-    assert linear_node.config.in_features == 5
-    assert linear_node.config.out_features == 6
+    assert isinstance(linear_node.nn_init, Linear)
+    assert linear_node.nn_init.in_features == 5
+    assert linear_node.nn_init.out_features == 6
 
     assert len(built.input_nodes) == 1
     assert len(built.output_nodes) == 1
@@ -43,7 +43,7 @@ def test_just_linear_supervised(input_space: SchemaSpace, output_space: SchemaSp
 
     for node in supervised.output_nodes:
         assert isinstance(node, NnHop)
-        assert isinstance(node.config, NnInit)
+        assert isinstance(node.nn_init, NnInit)
 
         # Right now only `nn.sMSELoss`.
-        assert node.config.NN == nn.MSELoss
+        assert node.nn_init.NN == nn.MSELoss

--- a/tests/hop/test_hop.py
+++ b/tests/hop/test_hop.py
@@ -55,3 +55,20 @@ def test_hop_linear(tensor_init: TensorHop, maybe_cache_hop):
     result = linear()
     assert isinstance(result, torch.Tensor)
     assert result.shape == (100, 31)
+
+
+def test_layer_hop_rebuild(layer_thunk, tensor_init: TensorHop, maybe_cache_hop):
+    hop = build_nn_hop(layer_thunk, tensor_init)
+    assert isinstance(hop, NnLayerHop)
+    assert all(isinstance(param, nn.Parameter) for param in hop.parameters())
+
+    rebuilt = hop.rebuild()
+    assert rebuilt is not hop
+
+
+def test_loss_hop_rebuild(loss_thunk, tensor_init: TensorHop, maybe_cache_hop):
+    result = build_nn_hop(loss_thunk, tensor_init, tensor_init)
+    assert isinstance(result, NnLossHop)
+
+    rebuilt = result.rebuild()
+    assert rebuilt is not result

--- a/tests/hop/test_hop.py
+++ b/tests/hop/test_hop.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch import nn
 
+from aioway._torch import is_fake_tensor, torch_fake_mode
 from aioway.hop import NnLayerHop, NnLossHop, TensorHop, build_nn_hop, hop_cache_on
 from aioway.modes import NnInitFn
 
@@ -57,18 +58,16 @@ def test_hop_linear(tensor_init: TensorHop, maybe_cache_hop):
     assert result.shape == (100, 31)
 
 
-def test_layer_hop_rebuild(layer_thunk, tensor_init: TensorHop, maybe_cache_hop):
-    hop = build_nn_hop(layer_thunk, tensor_init)
-    assert isinstance(hop, NnLayerHop)
-    assert all(isinstance(param, nn.Parameter) for param in hop.parameters())
+def test_hop_linear_rebuild(tensor_init: TensorHop):
+    with torch_fake_mode():
+        linear = build_nn_hop(NnInitFn(nn.Linear, 30, 31), tensor_init)
+        assert linear
 
-    rebuilt = hop.rebuild()
-    assert rebuilt is not hop
+        result = linear()
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (100, 31)
+        assert is_fake_tensor(result)
 
-
-def test_loss_hop_rebuild(loss_thunk, tensor_init: TensorHop, maybe_cache_hop):
-    result = build_nn_hop(loss_thunk, tensor_init, tensor_init)
-    assert isinstance(result, NnLossHop)
-
-    rebuilt = result.rebuild()
-    assert rebuilt is not result
+    linear = linear.rebuild()
+    result = linear()
+    assert not is_fake_tensor(result)


### PR DESCRIPTION
This is useful because we make heavy use of context managers.

For example, we can use fake mode to build, and then rebuild in real mode once ready.

Fix #237