### PR TITLE
`Emitter`s to use input `Hop` + output `Space`

### DIFF
--- a/src/aioway/algos/supervised.py
+++ b/src/aioway/algos/supervised.py
@@ -1,12 +1,10 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 import typing
-from collections import abc as cabc
 
 from aioway.compilers import Emitter, JustLinearEmitter, emitter_dcls
-from aioway.dsets import Dset, TensorStream
-from aioway.hop import ListHop, MSELoss
-from aioway.sinks import Sink
+from aioway.hop import ListHop, MSELoss, TensorHop
+from aioway.spaces import ShapeSpace
 
 __all__ = ["SupervisedAlgo"]
 
@@ -17,8 +15,8 @@ class SupervisedAlgo(Emitter):
     The supervised learning algorithm. Currently supports 1 input 1 output.
     """
 
-    input_data: TensorStream
-    target_data: Sink
+    input_data: TensorHop
+    target_data: TensorHop
 
     @typing.no_type_check
     def __call__(self) -> ListHop:
@@ -33,10 +31,6 @@ class SupervisedAlgo(Emitter):
 
     @property
     def just_linear(self) -> JustLinearEmitter:
-        return JustLinearEmitter(self.input_data, self.target_data)
-
-    def inputs(self) -> cabc.Iterator[Dset]:
-        yield self.input_data
-
-    def outputs(self) -> cabc.Iterator[Sink]:
-        yield self.target_data
+        return JustLinearEmitter(
+            self.input_data, ShapeSpace(self.target_data.attr.shape)
+        )

--- a/src/aioway/compilers/emits.py
+++ b/src/aioway/compilers/emits.py
@@ -5,11 +5,10 @@ import dataclasses as dcls
 import typing
 from collections import abc as cabc
 
+from aioway._utils import decomp_flatten
 from aioway.builders import TensorBuilder
-from aioway.dsets import Dset, TensorStream
-from aioway.hop import Linear, ListHop, LoaderOpt
-from aioway.sinks import Sink
-from aioway.spaces import AttrSpace
+from aioway.hop import Hop, Linear, ListHop, TensorHop
+from aioway.spaces import ShapeSpace, Space
 
 __all__ = ["Emitter", "emitter_dcls", "JustLinearEmitter"]
 
@@ -21,22 +20,36 @@ def emitter_dcls(cls):
 
 @emitter_dcls
 class Emitter(abc.ABC):
+    """
+    `Emitter` emits an additional `Hop` that can be added on top of the current `Hop` network,
+    providing additional transformation on top of what we currently have.
+
+    An `Emitter` should raise an error in `__post_init__` if the inputs are wrong.
+    """
+
     @abc.abstractmethod
-    def __call__(self) -> ListHop:
+    def __call__(self) -> Hop:
         """
         Compiles from a list of input and output tags.
-        Returns `NotImplemented` if the current builder does not support the inputs outputs.
         """
 
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def inputs(self) -> cabc.Iterator[Dset]:
-        raise NotImplementedError
+    def inputs(self) -> cabc.Iterator[Hop]:
+        """
+        In the current version of the design, an `Emitter` adds something to a `Hop`.
+        Therefore we could store the input `Hop` onto itself.
+        """
 
-    @abc.abstractmethod
-    def outputs(self) -> cabc.Iterator[Sink]:
-        raise NotImplementedError
+        yield from decomp_flatten(self, Hop)
+
+    def outputs(self) -> cabc.Iterator[Space]:
+        """
+        In the current version of the design,
+        an `Emitter` would store the output spaces onto itself.
+        """
+
+        yield from decomp_flatten(self, Space)
 
 
 @emitter_dcls
@@ -45,42 +58,19 @@ class JustLinearEmitter(Emitter):
     A builder that outputs 1 linear layer, supporting 1 input and 1 output.
     """
 
-    in_dset: TensorStream
-    "The input shape."
+    input: TensorHop
+    "The input `Hop`."
 
-    out_dset: Sink
-    "The output shape."
-
-    opts: LoaderOpt = LoaderOpt()
-    "The default data loader options."
+    output: ShapeSpace
+    "The output contract."
 
     def __post_init__(self) -> None:
-        assert isinstance(self.in_dset, Dset)
-        assert isinstance(self.out_dset, Sink)
+        assert isinstance(self.input, TensorHop)
+        assert isinstance(self.output, ShapeSpace)
 
     def __call__(self) -> ListHop:
-        try:
-            in_attr = self.in_attr.to_attr()
-            out_attr = self.out_attr.to_attr()
-        except TypeError:
-            return NotImplemented
-
-        input_node = TensorBuilder(self.in_dset(self.opts))
+        input_node = TensorBuilder(self.input)
         linear_node = input_node.apply_layer(
-            Linear(in_attr.shape[-1], out_attr.shape[-1]),
+            Linear(self.input.attr.shape[-1], self.output[-1]),
         )
         return ListHop([linear_node.hop])
-
-    @property
-    def in_attr(self) -> AttrSpace:
-        raise NotImplementedError
-
-    @property
-    def out_attr(self) -> AttrSpace:
-        raise NotImplementedError
-
-    def inputs(self) -> cabc.Iterator[Dset]:
-        yield self.in_dset
-
-    def outputs(self) -> cabc.Iterator[Sink]:
-        yield self.out_dset

--- a/src/aioway/dsets/dsets.py
+++ b/src/aioway/dsets/dsets.py
@@ -12,7 +12,6 @@ import torch
 from torch.utils import data
 
 from aioway.hop import LoaderHop, LoaderOpt, TdictLoaderHop, TensorLoaderHop
-from aioway.spaces import SpaceList
 
 __all__ = [
     "Dset",
@@ -78,14 +77,6 @@ class Dset[T](data.Dataset[T]):
 
         if sess := DsetSession.current():
             sess.push(self)
-
-    @property
-    def tags(self) -> SpaceList:
-        """
-        The tags associated with the data.
-        """
-
-        return SpaceList()
 
 
 @dset_dcls

--- a/src/aioway/hop/hop.py
+++ b/src/aioway/hop/hop.py
@@ -18,7 +18,9 @@ from aioway._utils import (
     decomp_dcls_members,
     decomp_replace,
     topo_sort,
+    torch_fake_mode,
 )
+from aioway.spaces import Attr
 
 __all__ = ["hop_dcls", "Hop", "TensorHop", "TdictHop", "ListHop", "BoundedHop"]
 
@@ -56,6 +58,15 @@ class Hop[T](cabc.Iterable[T], abc.ABC):
         """
 
         raise NotImplementedError
+
+    def sample(self) -> T:
+        """
+        Get a sample from the input. This method should be equivalent to `next(iter(self))`,
+        but in fake mode (no data is actually retrieved).
+        """
+
+        with torch_fake_mode():
+            return next(iter(self))
 
     @property
     def requires_grad(self) -> bool:
@@ -157,6 +168,10 @@ class TensorHop(Hop[torch.Tensor], abc.ABC):
     """
     An iterator of batches of `torch.Tensor`.
     """
+
+    @property
+    def attr(self) -> Attr:
+        return Attr.parse(self.sample())
 
 
 @hop_dcls

--- a/src/aioway/sinks.py
+++ b/src/aioway/sinks.py
@@ -7,7 +7,6 @@ import dataclasses as dcls
 import typing
 
 from aioway.hop import Hop
-from aioway.spaces import SpaceList
 
 __all__ = ["Sink", "sink_dcls"]
 
@@ -38,7 +37,3 @@ class Sink[T = typing.Any](abc.ABC):
     @abc.abstractmethod
     def write(self, batch: T, /) -> None:
         raise NotImplementedError
-
-    @property
-    def tags(self):
-        return SpaceList()

--- a/src/aioway/spaces/dims.py
+++ b/src/aioway/spaces/dims.py
@@ -7,6 +7,8 @@ import functools
 import re
 import typing
 
+import torch
+
 from aioway.spaces import Attr
 
 from .spaces import TensorSpace, space_dcls
@@ -47,13 +49,16 @@ class DimInfo(enum.StrEnum):
 
 @space_dcls
 class DimSpace(TensorSpace):
-    NAME = "__aioway_dim_tag__"
 
     tags: str
     """
     The tags. For efficiency purposes we store it in strings.
     Strings are more compact and we can use regex.
     """
+
+    def __post_init__(self) -> None:
+        if not _valid_dim_tag(self.tags):
+            raise ValueError("The dimension tags are not valid.")
 
     @typing.override
     def _check_attr(self, attr: Attr) -> None:
@@ -62,9 +67,20 @@ class DimSpace(TensorSpace):
                 f"The {self.tags=} dimensions do not match the tensor's {ndim=}."
             )
 
-    def __post_init__(self) -> None:
-        if not _valid_dim_tag(self.tags):
-            raise ValueError("The dimension tags are not valid.")
+    @typing.override
+    def _check_data(self, data: torch.Tensor) -> None:
+        if DimInfo.PROB.value not in self.tags:
+            return
+
+        # Probability dims should sum to 1.
+        prob_dims = [i for i, tag in enumerate(self.tags) if tag == DimInfo.PROB.value]
+
+        for dim in prob_dims:
+            summation = data.sum(dim=dim)
+            ones = torch.ones_like(summation)
+
+            if not torch.allclose(summation, ones):
+                raise ValueError
 
 
 def _valid_dim_tag(tags: str) -> bool:

--- a/src/aioway/spaces/exact.py
+++ b/src/aioway/spaces/exact.py
@@ -1,13 +1,56 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+"The contract that forces the checked data to be exact."
+
 import dataclasses as dcls
 import typing
+from collections import abc as cabc
 
 from aioway.spaces import Attr, Device, DType, Layout, Shape
 
 from .spaces import TensorSpace, space_dcls
 
-__all__ = ["AttrSpace"]
+__all__ = ["AttrSpace", "ShapeSpace", "DTypeSpace"]
+
+
+@space_dcls
+class ShapeSpace(TensorSpace):
+    """
+    Check if the `torch.Tensor` has the same shape.
+    """
+
+    shape: Shape
+    """
+    The shape to check.
+    """
+
+    def __len__(self) -> int:
+        return len(self.shape)
+
+    def __getitem__(self, idx: int) -> int:
+        return self.shape[idx]
+
+    def _check_attr(self, attr: Attr) -> None:
+        if self.shape == attr.shape:
+            return
+
+        raise ValueError
+
+
+@space_dcls
+class DTypeSpace(TensorSpace):
+    """
+    Check if the `torch.Tensor` has one of the dtypes.
+    """
+
+    dtypes: cabc.Sequence[DType]
+    """
+    The shape to check.
+    """
+
+    def _check_attr(self, attr: Attr) -> None:
+        if attr.dtype not in self.dtypes:
+            raise ValueError
 
 
 @space_dcls
@@ -15,8 +58,6 @@ class AttrSpace(TensorSpace):
     """
     Tag that specify `Attr`s that should be respected.
     """
-
-    NAME = "__aioway_attr__"
 
     _: dcls.KW_ONLY
 

--- a/src/aioway/spaces/spaces.py
+++ b/src/aioway/spaces/spaces.py
@@ -59,7 +59,7 @@ class Space[T = typing.Any](abc.ABC):
 
 @space_dcls
 class TensorSpace(Space[torch.Tensor]):
-    "A `Tag` that tags itself onto a `torch.Tensor`."
+    "A `Space` that enforces constraints on a `torch.Tensor`."
 
     @typing.override
     def contains(self, value: torch.Tensor, /) -> bool:
@@ -89,7 +89,7 @@ class TensorSpace(Space[torch.Tensor]):
 
 @space_dcls
 class TdictSpace(Space[td.TensorDict]):
-    "A `Tag` that tags `td.TensorDict`."
+    "A `Space` that checks a `td.TensorDict`."
 
     @typing.override
     def contains(self, value: td.TensorDict, /) -> bool:
@@ -121,7 +121,7 @@ class TdictSpace(Space[td.TensorDict]):
 class SpaceList[T = typing.Any](Space[T]):
     """
     The tags stored on an object can be extracted into a `TagDict`,
-    which supports both fast lookup and conveniently unpacks to only `Tag`s.
+    which supports both fast lookup and conveniently unpacks to only `Space`s.
     """
 
     spaces: cabc.Sequence[Space[T]] = ()

--- a/tests/compilers/test_emitters.py
+++ b/tests/compilers/test_emitters.py
@@ -7,7 +7,7 @@ from torch import nn
 
 from aioway.algos import SupervisedAlgo
 from aioway.compilers import JustLinearEmitter
-from aioway.dsets import Stream, TensorListHop, TensorStream
+from aioway.dsets import TensorListHop, TensorStream
 from aioway.hop import Linear, ListHop, LoaderOpt, NnHop, NnInit, NnLayerHop, TensorHop
 from aioway.spaces import Attr, AttrSpace, Shape, ShapeSpace
 
@@ -37,14 +37,22 @@ def input_dataset(input_space: AttrSpace):
 
 
 @pytest.fixture
-def supervised(input_dataset: Stream, output_space: ShapeSpace):
-    pytest.xfail("Not yet")
-    return SupervisedAlgo(input_dataset, output_space)
+def input_hop(input_dataset: TensorStream) -> TensorHop:
+    return input_dataset(LoaderOpt())
 
 
-def test_just_linear(input_dataset: TensorStream, output_space: ShapeSpace):
-    stream = input_dataset(LoaderOpt())
-    builder = JustLinearEmitter(stream, output_space)
+@pytest.fixture
+def target_hop(input_hop: TensorHop) -> TensorHop:
+    return input_hop
+
+
+@pytest.fixture
+def supervised(input_hop: TensorHop, target_hop: TensorHop):
+    return SupervisedAlgo(input_hop, target_hop)
+
+
+def test_just_linear(input_hop: TensorHop, output_space: ShapeSpace):
+    builder = JustLinearEmitter(input_hop, output_space)
     built = builder()
     [tensor_node, linear_node, list_node] = built.dag()
     assert isinstance(linear_node, NnLayerHop)

--- a/tests/compilers/test_emitters.py
+++ b/tests/compilers/test_emitters.py
@@ -7,10 +7,9 @@ from torch import nn
 
 from aioway.algos import SupervisedAlgo
 from aioway.compilers import JustLinearEmitter
-from aioway.dsets import Stream, TensorListHop
-from aioway.hop import Linear, ListHop, NnHop, NnInit, NnLayerHop, TensorHop
-from aioway.sinks import Sink
-from aioway.spaces import Attr, AttrSpace, SpaceList
+from aioway.dsets import Stream, TensorListHop, TensorStream
+from aioway.hop import Linear, ListHop, LoaderOpt, NnHop, NnInit, NnLayerHop, TensorHop
+from aioway.spaces import Attr, AttrSpace, Shape, ShapeSpace
 
 
 @pytest.fixture
@@ -20,14 +19,12 @@ def input_space():
 
 @pytest.fixture
 def output_space():
-    return AttrSpace.from_attr(Attr.build(dtype="float", shape=[3, 4, 6]))
+    return ShapeSpace(Shape.parse(3, 4, 6))
 
 
 @pytest.fixture
 def input_dataset(input_space: AttrSpace):
-    pytest.xfail("inputs outputs change")
-
-    class FakeInputDset(Stream):
+    class FakeInputDset(TensorStream):
         def __call__(self, *_):
             return TensorListHop([input_space.to_attr().to_fake_tensor()])
 
@@ -36,37 +33,18 @@ def input_dataset(input_space: AttrSpace):
             # Not really using this, so we can afford to make a fake one.
             raise NotImplementedError
 
-        @property
-        def tags(self):
-            return SpaceList({input_space.NAME: input_space})
-
     return FakeInputDset()
 
 
 @pytest.fixture
-def output_dataset(output_space: AttrSpace):
-    pytest.xfail("inputs outputs change")
-
-    class FakeOutputDset(Sink):
-        @typing.override
-        def write(self, item):
-            # Not really using this, so we can afford to make a fake one.
-            raise NotImplementedError
-
-        @property
-        def tags(self):
-            return SpaceList({output_space.NAME: output_space})
-
-    return FakeOutputDset()
+def supervised(input_dataset: Stream, output_space: ShapeSpace):
+    pytest.xfail("Not yet")
+    return SupervisedAlgo(input_dataset, output_space)
 
 
-@pytest.fixture
-def supervised(input_dataset, output_dataset):
-    return SupervisedAlgo(input_dataset, output_dataset)
-
-
-def test_just_linear(input_dataset: Stream, output_dataset: Sink):
-    builder = JustLinearEmitter(input_dataset, output_dataset)
+def test_just_linear(input_dataset: TensorStream, output_space: ShapeSpace):
+    stream = input_dataset(LoaderOpt())
+    builder = JustLinearEmitter(stream, output_space)
     built = builder()
     [tensor_node, linear_node, list_node] = built.dag()
     assert isinstance(linear_node, NnLayerHop)


### PR DESCRIPTION
Make `Emitter`s flexible to use (not dependent on `Frame` / `Stream`), yet making it concrete enough to reduce complexity (depends on input `Hop` simplifies implementation).

Fix #327.